### PR TITLE
jetson-xavier: Switch to BETA

### DIFF
--- a/jetson-xavier.coffee
+++ b/jetson-xavier.coffee
@@ -11,7 +11,6 @@ module.exports =
 	name: 'Nvidia Jetson Xavier'
 	arch: 'aarch64'
 	state: 'experimental'
-	community: true
 
 	instructions: [
 		BOARD_PREPARE


### PR DESCRIPTION
Currently the xavier is marked as community,
but support for it was added by Balena.
Switch this board to BETA.

Changelog-entry: jetson-xavier: Switch to BETA
Signed-off-by: Alexandru Costache <alexandru@balena.io>