### PR TITLE
jetson-nano: load kernel from rootfs

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra/load-extlinux.conf-and-kernel-from-root-partit.patch
+++ b/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra/load-extlinux.conf-and-kernel-from-root-partit.patch
@@ -1,0 +1,33 @@
+From 1a0cd97c8ba417ee95f9f215a765b5bcab164b5a Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Mon, 16 Dec 2019 14:40:34 +0100
+Subject: [PATCH] uboot: Load extlinux.conf and kernel from root partition
+
+Loading the kernel from the boot partition causes problems
+after a rollback-altboot, when the kernel did not boot
+completely into the rootfs. A new kernel will try to
+load the old modules from the rootfs and fail, leaving
+the board disconnected from the dashboard.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ include/config_distro_bootcmd.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
+index 5222ed366a..728ab6cab6 100644
+--- a/include/config_distro_bootcmd.h
++++ b/include/config_distro_bootcmd.h
+@@ -379,7 +379,7 @@
+ 		"\0"                                                      \
+ 	\
+ 	"scan_dev_for_boot_part="                                         \
+-		"part list ${devtype} ${devnum} -bootable devplist; "     \
++                "setenv devplist $resin_root_part; "                      \
+ 		"env exists devplist || setenv devplist $defaultdevplist; "\
+ 		"for distro_bootpart in ${devplist}; do "                 \
+ 			"if fstype ${devtype} "                           \
+-- 
+2.17.1
+

--- a/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -18,6 +18,7 @@ SRC_URI_append = " \
 
 SRC_URI_append_jetson-nano = " \
     file://nano-Integrate-with-Balena-u-boot-environment.patch \
+    file://load-extlinux.conf-and-kernel-from-root-partit.patch \
 "
 
 # In l4t 28.2 below partitions were 0xC and 0xD

--- a/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -12,12 +12,12 @@ SRCREV = "8e576d30001dc06552b017fab22e00fe7145b8da"
 # These changes are necessary since balenaOS 2.39.0
 # for all boards that use u-boot
 SRC_URI_append = " \
-        file://0001-Increase-default-u-boot-environment-size.patch \
-        file://0001-menu-Use-default-menu-entry-from-extlinux.conf.patch \
+    file://0001-Increase-default-u-boot-environment-size.patch \
+    file://0001-menu-Use-default-menu-entry-from-extlinux.conf.patch \
 "
 
 SRC_URI_append_jetson-nano = " \
-	file://nano-Integrate-with-Balena-u-boot-environment.patch \
+    file://nano-Integrate-with-Balena-u-boot-environment.patch \
 "
 
 # In l4t 28.2 below partitions were 0xC and 0xD
@@ -28,3 +28,23 @@ SRC_URI_append_jetson-tx2 = " \
     file://0001-Add-part-index-command.patch \
     file://tx2-Integrate-with-Balena-u-boot-environment.patch \
 "
+
+# extlinux will now be installed in the rootfs,
+# near the kernel, initrd is not used
+do_install_append() {
+    # Remove generic extlinux.conf added by do_create_extlinux_config()
+    rm -rf "${D}/boot/extlinux/extlinux.conf"
+    rm -rf "${D}/boot/initrd" \
+
+    install -d ${D}/boot/extlinux
+    install -m 0644 ${DEPLOY_DIR_IMAGE}/boot/extlinux.conf ${D}/boot/extlinux/extlinux.conf
+    sed -i 's/Image/boot\/Image/g' ${D}/boot/extlinux/extlinux.conf
+}
+
+# Free up some space from rootfs
+FILES_u-boot-tegra_remove = " \
+    /boot/initrd \
+"
+
+# Our extlinux is provided by the kernel
+do_install[depends] += " virtual/kernel:do_deploy"

--- a/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
@@ -9,8 +9,6 @@ DTBFILE_jn30b-nano = "tegra210-p3448-0002-p3449-0000-b00-jn30b-JP4.2.2.dtb"
 
 # Name update files as partition names for easier updating
 RESIN_BOOT_PARTITION_FILES_jetson-nano = " \
-    boot/extlinux.conf:/extlinux/extlinux.conf \
-    ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
     bootfiles/nvtboot_cpu.bin.encrypt:/bootfiles/TBC \
     bootfiles/${DTBFILE}.encrypt:/bootfiles/RP1 \
     bootfiles/cboot.bin.encrypt:/bootfiles/EBT \


### PR DESCRIPTION
This fixes rollback-altboot issues where board won't get online after a failed HUP to a version that contains a kernel update: https://github.com/balena-os/balena-jetson/issues/17

A separate PR will be done for the TX2 which, unlinke the nano, uses the uboot from emmc when loading a flasher image from the sd-card.