### PR TITLE
resin-image-initramfs: Remove unnecessary IMAGE_ROOTFS_MAXSIZE override

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/resin-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,5 +1,2 @@
-IMAGE_ROOTFS_MAXSIZE = "12300"
-IMAGE_ROOTFS_MAXSIZE_jetson-tx2 = "16400"
-
 PACKAGE_INSTALL_append = " tegra-firmware-xusb"
 PACKAGE_INSTALL_append_jetson-tx2 = " kernel-module-bcmdhd"


### PR DESCRIPTION
This is unnecessary since 2.47+

See https://github.com/balena-os/meta-balena/pull/1813 for more detail

Changelog-entry: Remove unnecessary override of IMAGE_ROOTFS_MAXSIZE
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>