### PR TITLE
linux-firmware: Add firmware for the Intel 9260 wifi chipset

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,4 +1,5 @@
 CONNECTIVITY_FIRMWARES_append_jetson-nano = " \
     linux-firmware-iwlwifi-8265 \
+    linux-firmware-iwlwifi-9260 \
     linux-firmware-ibt-12-16 \
 "

--- a/layers/meta-balena-jetson/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -1,1 +1,9 @@
 IWLWIFI_FW_MIN_API[8265] = "22"
+
+PACKAGES =+ "${PN}-iwlwifi-9260"
+FILES_${PN}-iwlwifi-9260 = " \
+    ${nonarch_base_libdir}/firmware/iwlwifi-9260-* \
+    "
+
+LICENSE_${PN}-iwlwifi-9260 = "Firmware-iwlwifi_firmware"
+RDEPENDS_${PN}-iwlwifi-9260 = "${PN}-iwlwifi-license"


### PR DESCRIPTION
Customer request to add firmware for the Intel 9260 wifi
adapter

Changelog-entry: Add firmware for the Intel 9260 wifi adapter
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>