### PR TITLE
os-helpers-fs: Fallback to labels and partlabels if state links missing

### DIFF
--- a/layers/meta-balena-jetson/recipes-support/os-helpers/os-helpers.bbappend
+++ b/layers/meta-balena-jetson/recipes-support/os-helpers/os-helpers.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_append := "${THISDIR}/${PN}"
+
+# We use this for the Jetson Nano to HUP from
+# any older release that doesn't boot using UUID but PARTUUID
+SRC_URI_append = "file://os-helpers-fs-Fallback-to-labels-and-partlabels-if-s.patch"

--- a/layers/meta-balena-jetson/recipes-support/os-helpers/os-helpers/os-helpers-fs-Fallback-to-labels-and-partlabels-if-s.patch
+++ b/layers/meta-balena-jetson/recipes-support/os-helpers/os-helpers/os-helpers-fs-Fallback-to-labels-and-partlabels-if-s.patch
@@ -1,0 +1,38 @@
+From a7c5510982e7472f06c3f8d04f6e7d701b90346e Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Tue, 26 May 2020 16:09:07 +0200
+Subject: [PATCH] os-helpers-fs: Fallback to labels and partlabels if state
+ links missing
+
+Some devices like the Jetson NX and Xabier cannot modify their bootloader
+(cboot) to pass UUIDs, so a device tree is used to pass a LABEL= root
+drive. These devices now fallback to the legacy way of partition detection.
+
+Also, HUP scripts on Jetson devices run BSP partition update scripts and
+these need to fallback to partname resolution.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ os-helpers-fs | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/os-helpers-fs b/os-helpers-fs
+index 87f0733..7248b5a 100644
+--- a/os-helpers-fs
++++ b/os-helpers-fs
+@@ -61,7 +61,9 @@ get_cmdline_root_uuid() {
+ #  by-state symlink udev path
+ get_state_path_from_label() {
+ 	[ -z "$1" ] && return 1
+-	echo "/dev/disk/by-state/${1}"
++	[ -L "/dev/disk/by-state/${1}" ] && echo "/dev/disk/by-state/${1}" && return 0
++	[ -L "/dev/disk/by-label/${1}" ] && echo "/dev/disk/by-label/${1}" && return 0
++	[ -L "/dev/disk/by-partlabel/${1}" ] && echo "/dev/disk/by-partlabel/${1}" && return 1
+ }
+ 
+ # Output the UUID for the specified block device.
+-- 
+2.17.1
+


### PR DESCRIPTION
Some devices like the Jetson NX and Xavier cannot modify their bootloader
(cboot) to pass UUIDs, so a device tree is used to pass a LABEL= root
drive. These devices now fallback to the legacy way of partition detection.

Also, HUP scripts on Jetson devices run BSP partition update scripts and
these need to fallback to partname resolution.

Patch provided by Alex Gonzalez.

Changelog-entry: Fallback to labels and partlabels for Jetson devices
Signed-off-by: Alex Gonzalez <alexg@balena.io>
Signed-off-by: Alexandru Costache <alexandru@balena.io>