### PR TITLE
hostapp-update-hooks: Fix resin-bootfiles script for Xavier

### DIFF
--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
@@ -11,8 +11,7 @@ set -o errexit
 new_part=$(findmnt --noheadings --canonicalize --output SOURCE "/mnt/sysroot/inactive" -t ext4)
 echo "New partition is ${new_part}"
 
-blockdev=$(basename "$new_part")
-rootstr=$(get_dev_label "${blockdev}")
+rootstr=$(get_dev_label "${new_part}")
 rootl=""
 
 case "$rootstr" in


### PR DESCRIPTION
Use the whole device path to call get_dev_label().

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>