### PR TITLE
Updates 2020.07.x

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/resin-image-flasher.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image-flasher.bbappend
@@ -1,6 +1,10 @@
 include resin-image.inc
 
 RESIN_BOOT_PARTITION_FILES_append_jetson-tx2 = " \
+    ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
+"
+
+RESIN_BOOT_PARTITION_FILES_append_jetson-tx2 = " \
     boot/extlinux.conf_flasher:/extlinux/extlinux.conf \
 "
 RESIN_BOOT_PARTITION_FILES_append_jetson-tx1 = " \

--- a/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
@@ -55,7 +55,6 @@ do_rootfs_resinos-img_jetson-tx2[depends] += " tegra186-flash-dry:do_deploy \
 "
 
 RESIN_BOOT_PARTITION_FILES_jetson-tx2 = " \
-    ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
     boot/extlinux.conf:/extlinux/extlinux.conf \
 "
 


### PR DESCRIPTION
Update the meta-balena version to be in sync with the one that had the common tests ran for the RPI ESR.