### PR TITLE
Test signing by switching back to the last revision for t210

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -11,6 +11,7 @@ RESIN_DEFAULT_ROOT_PART_jetson-nano-emmc = "0xD"
 
 # Latest L4T 32.4.2 known to work revision of u-boot v2020.04
 SRCREV = "74a4f0bcbafa3b5a81821469cdec819bb2695df9"
+SRCREV_jetson-tx1 = "914e902b5d68976de59ae0849f2ede20b1f2f50d"
 
 # meta-balena patch does not apply cleanly, so we refactor it
 SRC_URI_remove = " file://resin-specific-env-integration-kconfig.patch "


### PR DESCRIPTION
u-boot-tegra: Switch back to previous revision for t210

Do so to preserve flashing nonces offsets in case
they were affected by u-boot update.

Changelog-entry: u-boot-tegra: Switch back to previous rev for t210
Signed-off-by: Alexandru Costache <alexandru@balena.io>