### PR TITLE
Install hooks and dependencies for all Jetson devices

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
@@ -145,10 +145,6 @@ IMAGE_INSTALL_append_jetson-tx2 = " \
     linux-firmware-bcm4354 \
     tegra-firmware-xusb \
     bt-scripts \
-    libnvidia-container-tools \
-    nvidia-container-toolkit \
-    nvidia-container-runtime \
-    go-runtime \
 "
 
 IMAGE_INSTALL_append_jetson-tx1 = " \
@@ -161,4 +157,11 @@ IMAGE_INSTALL_append_jetson-tx1 = " \
     tegra-brcm-patchram \
     linux-firmware-bcm4354 \
     bt-scripts \
+"
+
+IMAGE_INSTALL_append = " \
+    libnvidia-container-tools \
+    nvidia-container-toolkit \
+    nvidia-container-runtime \
+    go-runtime \
 "


### PR DESCRIPTION
BalenaOS is now preparing a solution for overlaying extra
content in the rootfs for any device type so let's install the
nvidia hook, csv and dependencies for all the boards in this
repository.