### PR TITLE
linux-tegra: Install custom options 6 dtb in rootfs

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -197,6 +197,15 @@ RESIN_CONFIGS[mii] = " \
                 CONFIG_MII=m \
 "
 
+RESIN_CONFIGS_append = " cfginput"
+RESIN_CONFIGS[cfginput] = " \
+		CONFIG_INPUT_LEDS=m \
+		CONFIG_FF_MEMLESS=m \
+		CONFIG_INPUT_MOUSEDEV=m \
+		CONFIG_INPUT_JOYDEV=m \
+		CONFIG_JOYSTICK_XPAD=m \
+"
+
 KERNEL_ROOTSPEC_jetson-nano = "\${resin_kernel_root} ro rootwait"
 KERNEL_ROOTSPEC_jetson-nano-emmc = "\${resin_kernel_root} ro rootwait"
 KERNEL_ROOTSPEC_jn30b-nano = "\${resin_kernel_root} ro rootwait"


### PR DESCRIPTION
tx2-6 custom dtb was missing from boot directory,
let's add it there.
Also, switched some built-in input drivers to modules
to save some space in the boot part for flasher images.

Changelog-entry: linux-tegra: Install custom options 6 dtb in rootfs
Signed-off-by: Alexandru Costache <alexandru@balena.io>