### PR TITLE
Preserve odm value during hup TX2, check where partitions need updating

### DIFF
--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/50-resin-bootfiles-jetson-tx2
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/50-resin-bootfiles-jetson-tx2
@@ -3,13 +3,51 @@
 . /usr/libexec/os-helpers-fs
 
 NVIDIA_PART_OFFSET="4097"
-DEV_PATH=/dev/mmcblk0
+DEV_PATH="/dev/mmcblk0"
+BOOT_PART="${DEV_PATH}boot0"
 UPGRADE_PARTITIONS=0
 BIN_INSTALL_PATH="/opt/tegra-binaries"
+OFFS=(1659 5243 18043)
+BOOT_BLOB="${BIN_INSTALL_PATH}/boot0.img"
+
+update_needed() {
+    current_update_file=${1}
+    device=${2}
+    update_size=$(ls -al $current_update_file | awk '{print $5}')
+    update_md5sum=$(md5sum $current_update_file | awk '{print $1'})
+
+    existing_md5sum=$(dd if=$device bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
+
+    if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
+        echo 1
+    else
+	echo 0
+    fi
+}
 
 info_log()
 {
     echo "[INFO] $@"
+}
+
+get_odm_value() {
+    odm_off1=$(dd if=${1} skip=${OFFS[0]} bs=1 count=1 status=none | xxd -p)
+    odm_off2=$(dd if=${1} skip=${OFFS[1]} bs=1 count=1 status=none | xxd -p)
+    odm_off3=$(dd if=${1} skip=${OFFS[2]} bs=1 count=1 status=none | xxd -p)
+
+    if [[ "${odm_off1}" == "${odm_off2}" ]] && [[ "${odm_off2}" == "${odm_off3}" ]]; then
+        echo "${odm_off1}";
+    else
+        echo "unmatched";
+    fi;
+}
+
+set_odm_value() {
+    for offset in ${OFFS[@]}
+    do
+        info_log "Writing ODM byte ${1} to ${2} at offset ${offset}"
+        echo -n -e "\\x${1}" | dd of=${2} seek=${offset} bs=1 count=1 conv=notrunc
+    done
 }
 
 update_partition_binaries()
@@ -17,7 +55,14 @@ update_partition_binaries()
     for line in $(cat $1); do
         part_name=$(echo $line | cut -d ':' -f 1)
         file_name=$(echo $line | cut -d ':' -f 2)
-        dd oflag=dsync if="${BIN_INSTALL_PATH}/${file_name}" of=$(get_state_path_from_label  "$part_name")
+	src="${BIN_INSTALL_PATH}/${file_name}"
+	dst=$(get_state_path_from_label  "$part_name")
+	if [ $(update_needed $src $dst) -eq 1 ]; then
+            info_log "Will update ${dst}"
+            dd oflag=dsync if=${src} of=${dst}
+        else
+            info_log "No need to update ${dst}"
+        fi
     done
 }
 
@@ -70,8 +115,31 @@ elif [ ${UPGRADE_PARTITIONS} -eq 0 ]; then
     update_partition_binaries "${BIN_INSTALL_PATH}/partition_specification186.txt"
 fi
 
-# Regardless of whether the GPT has been altered, update boot part
-echo 0 > /sys/block/mmcblk0boot0/force_ro
-dd if="${BIN_INSTALL_PATH}/boot0.img" of=/dev/mmcblk0boot0
+bootpart_odm=$(get_odm_value ${BOOT_PART});
+bootblob_odm=$(get_odm_value ${BOOT_BLOB});
+
+if [[ ${bootpart_odm} != "unmatched"} ]] && [[ ${bootblob_odm} != "unmatched" ]] ; then
+    info_log "Valid ODMDATA values found in both ${BOOT_PART} and ${BOOT_BLOB}"
+    if [[ ${bootpart_odm} == ${bootblob_odm} ]]; then
+        info_log "No need to transfer existing ODMDATA"
+    else
+        info_log "Existing ODMDATA ${bootpart_odm} does not match HUP ODMDATA ${bootblob_odm}"
+        set_odm_value ${bootpart_odm} ${BOOT_BLOB}
+    fi;
+else
+    echo "[WARNING] Unmatched ODMDATA, will not update HUP blob: ${bootpart_odm} - ${bootblob_odm}"
+fi
+
+src=${BOOT_BLOB}
+dst=${BOOT_PART}
+
+if [ $(update_needed $src $dst) -eq 1 ]; then
+    info_log "Will update $dst"
+    echo 0 > /sys/block/mmcblk0boot0/force_ro
+    dd oflag=dsync if=${src} of=${dst}
+    echo 1 > /sys/block/mmcblk0boot0/force_ro
+else
+    info_log "No need to update ${dst}"
+fi
+
 sync
-echo 1 > /sys/block/mmcblk0boot0/force_ro

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
@@ -6,10 +6,31 @@ set -o errexit
 
 bootfiles=$(ls /resin-boot/bootfiles/);
 
+update_needed() {
+    current_update_file=${1}
+    device=${2}
+    update_size=$(ls -al $current_update_file | awk '{print $5}')
+    update_md5sum=$(md5sum $current_update_file | awk '{print $1'})
+    existing_md5sum=$(dd if=$device bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
+
+    if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
 for bootfile in ${bootfiles}
 do
-    dd if="/resin-boot/bootfiles/$bootfile" of=$(get_state_path_from_label "$bootfile") bs=512
-    echo "Updated $bootfile partition..."
+    src="/resin-boot/bootfiles/$bootfile"
+    dst=$(get_state_path_from_label "$bootfile")
+
+    if [ $(update_needed $src $dst) -eq 1 ]; then
+        echo "Will update ${dst}..."
+        dd oflag=dsync if=${src} of=${dst} bs=512
+    else
+        info_log "No need to update ${dst}"
+    fi
 done
 
 sync

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
@@ -6,6 +6,11 @@ set -o errexit
 
 bootfiles=$(ls /resin-boot/bootfiles/);
 
+info_log()
+{
+    echo "[INFO] $@"
+}
+
 update_needed() {
     current_update_file=${1}
     device=${2}
@@ -26,7 +31,7 @@ do
     dst=$(get_state_path_from_label "$bootfile")
 
     if [ $(update_needed $src $dst) -eq 1 ]; then
-        echo "Will update ${dst}..."
+        info_log "Will update ${dst}..."
         dd oflag=dsync if=${src} of=${dst} bs=512
     else
         info_log "No need to update ${dst}"

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
@@ -10,7 +10,13 @@ set -o errexit
 
 partspec="/resin-boot/bootfiles/partition_specification194.txt"
 new_part=$(findmnt --noheadings --canonicalize --output SOURCE "/mnt/sysroot/inactive" -t ext4)
-echo "New partition is ${new_part}"
+
+info_log()
+{
+    echo "[INFO] $@"
+}
+
+info_log "New partition is ${new_part}"
 
 rootstr=$(get_dev_label "${new_part}")
 rootl=""
@@ -41,7 +47,7 @@ case "$rootstr" in
         ;;
 esac
 
-echo "New root is resin-root${rootl}"
+info_log "New root is resin-root${rootl}"
 
 dtbname=$(cat "$partspec" | grep "kernel-dtb_b" | cut -d ':' -f 2 | awk -F'_sigheader' '{print $1}')
 dtbfile="${dtbname}-root${rootl}_sigheader.dtb.encrypt"
@@ -66,31 +72,31 @@ for n in ${partitions}; do
     dst="$file_path"
 
     if [ $(update_needed $src $dst) -eq 1 ]; then
-        info_log "Will update ${dst} / ${dst}_b ..."
+        info_log "Will update ${dst}..."
         dd if=${src} of=${dst}
         dd if=${src} of="${dst}_b"
     else
-        info_log "No need to update ${dst} / ${dst}_b"
+        info_log "No need to update ${dst}"
     fi
 done
 
 # root is contained in the dtb cmdline, needs to be updated to switch rootfs
-echo "[INFO] Writing ${dtbfile} to specific partitions..."
+info_log "Writing ${dtbfile} to specific partitions..."
 dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "bootloader-dtb")
 dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "bootloader-dtb_b")
 dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "kernel-dtb")
 dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "kernel-dtb_b")
 
-echo "[INFO] Writing kernel ${kernel} to specific partitions..."
+info_log "Writing kernel ${kernel} to specific partitions..."
 
 dd if=/resin-boot/bootfiles/${kernel}  of=$(get_state_path_from_label "kernel")
 dd if=/resin-boot/bootfiles/${kernel}  of=$(get_state_path_from_label "kernel_b")
 
-echo "[INFO] Updating boot image on hw partition mmcblk0boot0..."
+info_log "Updating boot image on hw partition mmcblk0boot0..."
 
 echo 0 > /sys/block/mmcblk0boot0/force_ro
 dd if=/resin-boot/bootfiles/boot0.img of=/dev/mmcblk0boot0
 sync
 echo 1 > /sys/block/mmcblk0boot0/force_ro
 
-echo "Done."
+info_log "Done."

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
@@ -15,6 +15,20 @@ echo "New partition is ${new_part}"
 rootstr=$(get_dev_label "${new_part}")
 rootl=""
 
+update_needed() {
+    current_update_file=${1}
+    device=${2}
+    update_size=$(ls -al $current_update_file | awk '{print $5}')
+    update_md5sum=$(md5sum $current_update_file | awk '{print $1'})
+    existing_md5sum=$(dd if=$device bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
+
+    if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
 case "$rootstr" in
     *resin-rootA*)
         rootl="A"
@@ -48,12 +62,19 @@ for n in ${partitions}; do
         continue
     fi
 
-    echo "[INFO] Writing $file_name to $file_path"
+    src="/resin-boot/bootfiles/$file_name"
+    dst="$file_path"
 
-    dd if=/resin-boot/bootfiles/$file_name of=$file_path
-    dd if=/resin-boot/bootfiles/$file_name of=${file_path}_b
+    if [ $(update_needed $src $dst) -eq 1 ]; then
+        info_log "Will update ${dst} / ${dst}_b ..."
+        dd if=${src} of=${dst}
+        dd if=${src} of="${dst}_b"
+    else
+        info_log "No need to update ${dst} / ${dst}_b"
+    fi
 done
 
+# root is contained in the dtb cmdline, needs to be updated to switch rootfs
 echo "[INFO] Writing ${dtbfile} to specific partitions..."
 dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "bootloader-dtb")
 dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "bootloader-dtb_b")

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit-emmc
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit-emmc
@@ -17,6 +17,20 @@ echo "New partition is ${new_part}"
 rootstr=$(get_dev_label "${new_part}")
 rootl=""
 
+update_needed() {
+    current_update_file=${1}
+    device=${2}
+    update_size=$(ls -al $current_update_file | awk '{print $5}')
+    update_md5sum=$(md5sum $current_update_file | awk '{print $1'})
+    existing_md5sum=$(dd if=$device bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
+
+    if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
 case "$rootstr" in
     *resin-rootA*)
         rootl="A"
@@ -35,8 +49,8 @@ echo "New root is resin-root${rootl}"
 dtbname=$(cat "$partspec" | grep "kernel-dtb_b" | cut -d ':' -f 2 | awk -F'_sigheader' '{print $1}')
 dtbfile="${dtbname}-root${rootl}_sigheader.dtb.encrypt"
 kernel="boot_sigheader.img.encrypt"
-
 partitions=$(cat ${partspec})
+
 for n in ${partitions}; do
     part_name=$(echo $n | cut -d ':' -f 1)
     file_name=$(echo $n | cut -d ':' -f 2)
@@ -51,18 +65,24 @@ for n in ${partitions}; do
         continue
     fi
 
-    echo "[INFO] Writing $file_name to $file_path"
+    src="/opt/tegra-binaries/${file_name}"
+    dst="$file_path"
 
-    dd if=/opt/tegra-binaries/$file_name of=$file_path
-    dd if=/opt/tegra-binaries/$file_name of=${file_path}_b
+    if [ $(update_needed $src $dst) -eq 1 ]; then
+        info_log "Will update ${dst} / ${dst}_b ..."
+        dd if=${src} of=${dst}
+        dd if=${src} of="${dst}_b"
+    else
+        info_log "No need to update ${dst} / ${dst}_b"
+    fi
 done
 
+# DTB contains root partition, update is mandatory
 echo "[INFO] Writing ${dtbfile} to specific partitions..."
 dd if=/opt/tegra-binaries/${dtbfile} of=$(get_state_path_from_label "kernel-dtb")
 dd if=/opt/tegra-binaries/${dtbfile} of=$(get_state_path_from_label "kernel-dtb_b")
 
 echo "[INFO] Writing kernel ${kernel} to specific partitions..."
-
 dd if=/opt/tegra-binaries/${kernel}  of=$(get_state_path_from_label "kernel")
 dd if=/opt/tegra-binaries/${kernel}  of=$(get_state_path_from_label "kernel_b")
 

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit-emmc
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit-emmc
@@ -12,7 +12,13 @@ bootloader_device="/dev/mtdblock0"
 bootloader_blob="/opt/tegra-binaries/boot0.img"
 partspec="/opt/tegra-binaries/partition_specification194_nxde.txt"
 new_part=$(findmnt --noheadings --canonicalize --output SOURCE "/mnt/sysroot/inactive" -t ext4)
-echo "New partition is ${new_part}"
+
+info_log()
+{
+    echo "[INFO] $@"
+}
+
+info_log "New partition is ${new_part}"
 
 rootstr=$(get_dev_label "${new_part}")
 rootl=""
@@ -43,8 +49,7 @@ case "$rootstr" in
         ;;
 esac
 
-echo "New root is resin-root${rootl}"
-
+info_log "New root is resin-root${rootl}"
 
 dtbname=$(cat "$partspec" | grep "kernel-dtb_b" | cut -d ':' -f 2 | awk -F'_sigheader' '{print $1}')
 dtbfile="${dtbname}-root${rootl}_sigheader.dtb.encrypt"
@@ -69,20 +74,20 @@ for n in ${partitions}; do
     dst="$file_path"
 
     if [ $(update_needed $src $dst) -eq 1 ]; then
-        info_log "Will update ${dst} / ${dst}_b ..."
+        info_log "Will update ${dst} ..."
         dd if=${src} of=${dst}
         dd if=${src} of="${dst}_b"
     else
-        info_log "No need to update ${dst} / ${dst}_b"
+        info_log "No need to update ${dst}"
     fi
 done
 
 # DTB contains root partition, update is mandatory
-echo "[INFO] Writing ${dtbfile} to specific partitions..."
+info_log "Writing ${dtbfile} to specific partitions..."
 dd if=/opt/tegra-binaries/${dtbfile} of=$(get_state_path_from_label "kernel-dtb")
 dd if=/opt/tegra-binaries/${dtbfile} of=$(get_state_path_from_label "kernel-dtb_b")
 
-echo "[INFO] Writing kernel ${kernel} to specific partitions..."
+info_log "Writing kernel ${kernel} to specific partitions..."
 dd if=/opt/tegra-binaries/${kernel}  of=$(get_state_path_from_label "kernel")
 dd if=/opt/tegra-binaries/${kernel}  of=$(get_state_path_from_label "kernel_b")
 
@@ -90,13 +95,13 @@ existing_bootloader_md5sum=$(dd if=$bootloader_device bs=1M status=none | md5sum
 update_bootloader_md5sum=$(md5sum $bootloader_blob | awk '{print $1}')
 
 if [ ! "$existing_bootloader_md5sum" = "$update_bootloader_md5sum" ]; then
-    echo "[INFO] Will update bootloader device"
+    info_log "Will update bootloader device"
     flash_erase /dev/mtd0 0 0
     dd if=$bootloader_blob of=$bootloader_device bs=1M
 else
-    echo "[INFO] No need to update bootloader device"
+    info_log "No need to update bootloader device"
 fi
 
 sync
 
-echo "Done."
+info_log "Done."


### PR DESCRIPTION
We want to preserve current flashed odmdata for the device that supports this currently, Jetson TX2, to prevent the case where the supervisor had already set a odm value which then gets overridden during HUP. This would trigger the supervisor to reboot the board before HUP is completed.

Also, usually partitions have their nonces updated during each build, but we should ensure however which do and which don't need the update.

Addresses: https://github.com/balena-os/balena-jetson/issues/103

Do not merge until tested on all boards.