### PR TITLE
fix machine overrides for photon-xavier-nx

### DIFF
--- a/layers/meta-balena-jetson/conf/machine/photon-xavier-nx.conf
+++ b/layers/meta-balena-jetson/conf/machine/photon-xavier-nx.conf
@@ -5,3 +5,7 @@
 
 MACHINEOVERRIDES = "jetson-xavier-nx-devkit-emmc:${MACHINE}"
 include conf/machine/jetson-xavier-nx-devkit-emmc.conf
+
+# work-around for https://github.com/OE4T/meta-tegra/issues/400
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':jetson-xavier-nx-devkit-emmc:${MACHINE}')}"
+


### PR DESCRIPTION
work-around for OE4T/meta-tegra#400 for photon-xavier-nx.

closes #111 