### PR TITLE
Allow to build tegra libraries recipes

### DIFF
--- a/layers/meta-balena-jetson/classes/features_check.bbclass
+++ b/layers/meta-balena-jetson/classes/features_check.bbclass
@@ -1,0 +1,8 @@
+# The Dunfell release renames distro_features_check to features_check
+# The meta-tegra layer is currently based on Dunfell
+inherit distro_features_check
+
+python() {
+    if 'dunfell' in d.getVar('DISTRO_CODENAME'):
+        bb.fatal("Please remove this class as dunfell includes a features_check class already")
+}

--- a/layers/meta-balena-jetson/conf/layer.conf
+++ b/layers/meta-balena-jetson/conf/layer.conf
@@ -24,7 +24,6 @@ BBMASK += "/meta-tegra/recipes-graphics/wayland "
 BBMASK += "/meta-tegra/recipes-graphics/xorg-xserver "
 BBMASK += "/meta-tegra/external/openembedded-layer/recipes-support/opencv/ "
 BBMASK += "/meta-tegra/recipes-multimedia/gstreamer/"
-BBMASK += "/meta-tegra/recipes-graphics/"
 BBMASK += "/meta-tegra/recipes-bsp/l4t-usb-device-mode/"
 
 LAYERSERIES_COMPAT_balena-jetson = "warrior"


### PR DESCRIPTION
* Masquerade the features_check class in Dunfell as distro_features_check to be able to build recipes from meta-tegra that use it
* Modify BBMASK to allow to build some meta-tegra/recipes-graphics recipes

Connects to: https://github.com/balena-os/balena-yocto-scripts/pull/177
Connects-to: https://github.com/balena-os/meta-balena/pull/1987