### PR TITLE
resin-image: Install tegra-udrm probeconf file for NX Devkit

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/resin-image.inc
@@ -155,6 +155,7 @@ IMAGE_INSTALL_append_jetson-xavier-nx-devkit = " \
     tegra-bluetooth \
     tegra-wifi \
     tegra-firmware-rtl8822 \
+    tegra-udrm-probeconf \
 "
 
 IMAGE_INSTALL_append_jetson-tx2 = " \


### PR DESCRIPTION
This is present in the official image for the NX Devkit,
let's add it our image too.

Changelog-entry: resin-image: Install tegra-udrm probeconf file for NX Devkit
Signed-off-by: Alexandru Costache <alexandru@balena.io>