### PR TITLE
hostapp-update-hooks: Add hooks for Nano 2GB

### DIFF
--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
@@ -12,6 +12,11 @@ HOSTAPP_HOOKS_append_jetson-nano-emmc = " 99-resin-uboot \
                                           99-resin-bootfiles-nano \
 "
 
+DEPENDS_append_jetson-nano-2gb-devkit    = " tegra210-flash"
+
+HOSTAPP_HOOKS_append_jetson-nano-2gb-devkit = " 99-resin-uboot \
+                                                99-resin-bootfiles-nano \
+
 DEPENDS_append_jetson-xavier  = " tegra194-flash-dry"
 DEPENDS_append_jetson-xavier-nx-devkit-emmc  = " tegra194-nxde-flash-dry"
 DEPENDS_append_jetson-xavier-nx-devkit  = " tegra194-nxde-sdcard-flash"

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
@@ -16,6 +16,7 @@ DEPENDS_append_jetson-nano-2gb-devkit    = " tegra210-flash"
 
 HOSTAPP_HOOKS_append_jetson-nano-2gb-devkit = " 99-resin-uboot \
                                                 99-resin-bootfiles-nano \
+"
 
 DEPENDS_append_jetson-xavier  = " tegra194-flash-dry"
 DEPENDS_append_jetson-xavier-nx-devkit-emmc  = " tegra194-nxde-flash-dry"


### PR DESCRIPTION
Changelog-entry: hostapp-update-hooks: Add hooks for Nano 2GB
Signed-off-by: Alexandru Costache <alexandru@balena.io>