### PR TITLE
Fix nvidia container runtime/toolkit to build with GO v1.12

### DIFF
--- a/layers/meta-balena-jetson/recipes-containers/nvidia-container-runtime/nvidia-container-runtime_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-containers/nvidia-container-runtime/nvidia-container-runtime_%.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 
 RDEPENDS_${PN} = ""
+# Remove this when using Go >= 1.13
+GOBUILDFLAGS = "-v ${GO_LDFLAGS}"

--- a/layers/meta-balena-jetson/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_%.bbappend
@@ -1,2 +1,5 @@
 # We don't need to build or install docker-ce and cuda-toolkit
 RDEPENDS_${PN} = ""
+
+# Remove this when using Go >= 1.13
+GOBUILDFLAGS = "-v ${GO_LDFLAGS}"


### PR DESCRIPTION
 Poky Dunfell is using Go v1.14 while meta-balena is still in v1.12. The -trimpath flag is introduced in v1.13 so we need to remove it from the build flags for the time being.

Poky defaulted to using -trimpath in commit 2d0c2242136e8c823d58218844c6e082122d0bce