### PR TITLE
Add contract for Tegra GPU overlay image

### DIFF
--- a/layers/meta-balena-jetson/contracts/sw.image/overlay/contract.json
+++ b/layers/meta-balena-jetson/contracts/sw.image/overlay/contract.json
@@ -1,0 +1,9 @@
+{
+  "slug": "overlay",
+  "version": "1.0.0",
+  "type": "sw.image",
+  "data": {
+    "reboot-required": "1",
+    "store": "data"
+  }
+}

--- a/layers/meta-balena-jetson/contracts/sw.image/service/contract.json
+++ b/layers/meta-balena-jetson/contracts/sw.image/service/contract.json
@@ -1,0 +1,9 @@
+{
+  "slug": "service",
+  "version": "1.0.0",
+  "type": "sw.image",
+  "data": {
+    "reboot-required": "0",
+    "store": "data"
+  }
+}

--- a/layers/meta-balena-jetson/contracts/sw.image/tegra-gpu/contract.json
+++ b/layers/meta-balena-jetson/contracts/sw.image/tegra-gpu/contract.json
@@ -1,0 +1,17 @@
+{
+  "slug": "tegra-gpu",
+  "type": "sw.image.overlay",
+  "name": "Overlay to provide Tegra GPU support",
+  "version": "1.0.0",
+  "requires": [
+    {
+      "anyOf": [
+        { "type": "hw.device-type", "slug": "jetson-tx2" },
+        { "type": "hw.device-type", "slug": "jetson-nano" }
+      ],
+      "allOf": [
+        { "type": "sw.package", "slug": "tegra-libraries" }
+      ]
+    }
+  ]
+}

--- a/layers/meta-balena-jetson/contracts/sw.package/tegra-libraries/contract.json
+++ b/layers/meta-balena-jetson/contracts/sw.package/tegra-libraries/contract.json
@@ -1,0 +1,29 @@
+{
+  "slug": "tegra-libraries",
+  "type": "sw.package",
+  "name": "Package list that provides Tegra GPU support",
+  "version": "1.0.0",
+  "requires": {
+	  "allOf" : [
+		  { "type": "sw.os", "slug": "yocto", "externalVersion": "dunfell"},
+		  { "type": "sw.os", "slug": "balenaos", "externalVersion": "2.x"}
+	  ]
+  },
+  "composedOf": [
+	  { "type": "sw.package.yocto.ipk", "slug": "tegra-libraries"},
+	  { "type": "sw.package.yocto.ipk", "slug": "libglvnd"},
+	  { "type": "sw.package.yocto.ipk", "slug": "libtirpc"},
+	  { "type": "sw.package.yocto.ipk", "slug": "libcap"},
+	  { "type": "sw.package.yocto.ipk", "slug": "elfutils"},
+	  { "type": "sw.package.yocto.ipk", "slug": "libelf"},
+	  { "type": "sw.package.yocto.ipk", "slug": "tegra-libraries-argus"},
+	  { "type": "sw.package.yocto.ipk", "slug": "tegra-libraries-argus-daemon-base"},
+	  { "type": "sw.package.yocto.ipk", "slug": "tegra-libraries-container-csv"},
+	  { "type": "sw.package.yocto.ipk", "slug": "tegra-libraries-libnvosd"},
+	  { "type": "sw.package.yocto.ipk", "slug": "tegra-libraries-libv4l-plugins"},
+	  { "type": "sw.package.yocto.ipk", "slug": "libnvidia-container-tools"},
+	  { "type": "sw.package.yocto.ipk", "slug": "nvidia-container-toolkit"},
+	  { "type": "sw.package.yocto.ipk", "slug": "nvidia-container-runtime"},
+	  { "type": "sw.package.yocto.ipk", "slug": "go-runtime"}
+  ]
+}


### PR DESCRIPTION
This commit adds to new types, `sw.image` and `sw.package` and introduces a `tegra-gpu` overlay image.