### PR TITLE
packagegroups: Add Ath10k and qca firmwares for TX2

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -9,3 +9,9 @@ CONNECTIVITY_FIRMWARES_append_jetson-nano-emmc = " \
     linux-firmware-iwlwifi-9260 \
     linux-firmware-ibt-12-16 \
 "
+
+CONNECTIVITY_FIRMWARES_append_jetson-tx2 = " \
+    linux-firmware-ath10k-qca6174 \
+    linux-firmware-qca \
+    linux-firmware-ath10k \
+"


### PR DESCRIPTION
We add these in the device repository since
these are needed for the TX2 only and we don't
want to take up space on devices where these
aren't needed.

Changelog-entry: packagegroups: Add Ath10k and qca firmwares for TX2
Signed-off-by: Alexandru Costache <alexandru@balena.io>