### PR TITLE
floyd-nano: Mark board as community device

### DIFF
--- a/floyd-nano.coffee
+++ b/floyd-nano.coffee
@@ -11,6 +11,7 @@ module.exports =
 	name: 'Floyd Nano BB02A eMMC'
 	arch: 'aarch64'
 	state: 'new'
+	community: 'true'
 
 	instructions: [
 		BOARD_PREPARE


### PR DESCRIPTION
Changelog-entry: floyd-nano: Mark board as community device
Signed-off-by: Alexandru Costache <alexandru@balena.io>