### PR TITLE
linux: enable crashdump support

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-memblock-add-memblock_cap_memory_range.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-memblock-add-memblock_cap_memory_range.patch
@@ -1,0 +1,114 @@
+From 125ddcd6382482a36892aab34e3b1b35204df9f8 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Mon, 3 Apr 2017 11:23:55 +0900
+Subject: [PATCH 1/3] memblock: add memblock_cap_memory_range()
+
+Add memblock_cap_memory_range() which will remove all the memblock regions
+except the memory range specified in the arguments. In addition, rework is
+done on memblock_mem_limit_remove_map() to re-implement it using
+memblock_cap_memory_range().
+
+This function, like memblock_mem_limit_remove_map(), will not remove
+memblocks with MEMMAP_NOMAP attribute as they may be mapped and accessed
+later as "device memory."
+See the commit a571d4eb55d8 ("mm/memblock.c: add new infrastructure to
+address the mem limit issue").
+
+This function is used, in a succeeding patch in the series of arm64 kdump
+suuport, to limit the range of usable memory, or System RAM, on crash dump
+kernel.
+(Please note that "mem=" parameter is of little use for this purpose.)
+
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Reviewed-by: Will Deacon <will.deacon@arm.com>
+Acked-by: Catalin Marinas <catalin.marinas@arm.com>
+Acked-by: Dennis Chen <dennis.chen@arm.com>
+Cc: linux-mm@kvack.org
+Cc: Andrew Morton <akpm@linux-foundation.org>
+Reviewed-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Signed-off-by: Catalin Marinas <catalin.marinas@arm.com>
+---
+ include/linux/memblock.h |  1 +
+ mm/memblock.c            | 44 ++++++++++++++++++++++++++--------------
+ 2 files changed, 30 insertions(+), 15 deletions(-)
+
+diff --git a/include/linux/memblock.h b/include/linux/memblock.h
+index 41fc841ade7e..c565fb053eea 100644
+--- a/include/linux/memblock.h
++++ b/include/linux/memblock.h
+@@ -336,6 +336,7 @@ phys_addr_t memblock_mem_size(unsigned long limit_pfn);
+ phys_addr_t memblock_start_of_DRAM(void);
+ phys_addr_t memblock_end_of_DRAM(void);
+ void memblock_enforce_memory_limit(phys_addr_t memory_limit);
++void memblock_cap_memory_range(phys_addr_t base, phys_addr_t size);
+ void memblock_mem_limit_remove_map(phys_addr_t limit);
+ bool memblock_is_memory(phys_addr_t addr);
+ int memblock_is_map_memory(phys_addr_t addr);
+diff --git a/mm/memblock.c b/mm/memblock.c
+index f92c05c2b038..b714fa276be1 100644
+--- a/mm/memblock.c
++++ b/mm/memblock.c
+@@ -1520,11 +1520,37 @@ void __init memblock_enforce_memory_limit(phys_addr_t limit)
+ 			      (phys_addr_t)ULLONG_MAX);
+ }
+ 
++void __init memblock_cap_memory_range(phys_addr_t base, phys_addr_t size)
++{
++	int start_rgn, end_rgn;
++	int i, ret;
++
++	if (!size)
++		return;
++
++	ret = memblock_isolate_range(&memblock.memory, base, size,
++						&start_rgn, &end_rgn);
++	if (ret)
++		return;
++
++	/* remove all the MAP regions */
++	for (i = memblock.memory.cnt - 1; i >= end_rgn; i--)
++		if (!memblock_is_nomap(&memblock.memory.regions[i]))
++			memblock_remove_region(&memblock.memory, i);
++
++	for (i = start_rgn - 1; i >= 0; i--)
++		if (!memblock_is_nomap(&memblock.memory.regions[i]))
++			memblock_remove_region(&memblock.memory, i);
++
++	/* truncate the reserved regions */
++	memblock_remove_range(&memblock.reserved, 0, base);
++	memblock_remove_range(&memblock.reserved,
++			base + size, (phys_addr_t)ULLONG_MAX);
++}
++
+ void __init memblock_mem_limit_remove_map(phys_addr_t limit)
+ {
+-	struct memblock_type *type = &memblock.memory;
+ 	phys_addr_t max_addr;
+-	int i, ret, start_rgn, end_rgn;
+ 
+ 	if (!limit)
+ 		return;
+@@ -1535,19 +1561,7 @@ void __init memblock_mem_limit_remove_map(phys_addr_t limit)
+ 	if (max_addr == (phys_addr_t)ULLONG_MAX)
+ 		return;
+ 
+-	ret = memblock_isolate_range(type, max_addr, (phys_addr_t)ULLONG_MAX,
+-				&start_rgn, &end_rgn);
+-	if (ret)
+-		return;
+-
+-	/* remove all the MAP regions above the limit */
+-	for (i = end_rgn - 1; i >= start_rgn; i--) {
+-		if (!memblock_is_nomap(&type->regions[i]))
+-			memblock_remove_region(type, i);
+-	}
+-	/* truncate the reserved regions */
+-	memblock_remove_range(&memblock.reserved, max_addr,
+-			      (phys_addr_t)ULLONG_MAX);
++	memblock_cap_memory_range(0, max_addr);
+ }
+ 
+ static int __init_memblock memblock_search(struct memblock_type *type, phys_addr_t addr)
+-- 
+2.31.1
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0002-arm64-limit-memory-regions-based-on-DT-property-usab.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0002-arm64-limit-memory-regions-based-on-DT-property-usab.patch
@@ -1,0 +1,78 @@
+From 5be4cefb2ba661a40c32b20782f7f9a72e94f5f3 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Mon, 3 Apr 2017 11:24:31 +0900
+Subject: [PATCH 2/3] arm64: limit memory regions based on DT property,
+ usable-memory-range
+
+Crash dump kernel uses only a limited range of available memory as System
+RAM. On arm64 kdump, This memory range is advertised to crash dump kernel
+via a device-tree property under /chosen,
+   linux,usable-memory-range = <BASE SIZE>
+
+Crash dump kernel reads this property at boot time and calls
+memblock_cap_memory_range() to limit usable memory which are listed either
+in UEFI memory map table or "memory" nodes of a device tree blob.
+
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Reviewed-by: Geoff Levand <geoff@infradead.org>
+Acked-by: Catalin Marinas <catalin.marinas@arm.com>
+Acked-by: Mark Rutland <mark.rutland@arm.com>
+Reviewed-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Signed-off-by: Catalin Marinas <catalin.marinas@arm.com>
+---
+ arch/arm64/mm/init.c | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/arch/arm64/mm/init.c b/arch/arm64/mm/init.c
+index 504d327f0f02..794780886b22 100644
+--- a/arch/arm64/mm/init.c
++++ b/arch/arm64/mm/init.c
+@@ -192,10 +192,45 @@ static int __init early_mem(char *p)
+ }
+ early_param("mem", early_mem);
+ 
++static int __init early_init_dt_scan_usablemem(unsigned long node,
++		const char *uname, int depth, void *data)
++{
++	struct memblock_region *usablemem = data;
++	const __be32 *reg;
++	int len;
++
++	if (depth != 1 || strcmp(uname, "chosen") != 0)
++		return 0;
++
++	reg = of_get_flat_dt_prop(node, "linux,usable-memory-range", &len);
++	if (!reg || (len < (dt_root_addr_cells + dt_root_size_cells)))
++		return 1;
++
++	usablemem->base = dt_mem_next_cell(dt_root_addr_cells, &reg);
++	usablemem->size = dt_mem_next_cell(dt_root_size_cells, &reg);
++
++	return 1;
++}
++
++static void __init fdt_enforce_memory_region(void)
++{
++	struct memblock_region reg = {
++		.size = 0,
++	};
++
++	of_scan_flat_dt(early_init_dt_scan_usablemem, &reg);
++
++	if (reg.size)
++		memblock_cap_memory_range(reg.base, reg.size);
++}
++
+ void __init arm64_memblock_init(void)
+ {
+ 	const s64 linear_region_size = -(s64)PAGE_OFFSET;
+ 
++	/* Handle linux,usable-memory-range property */
++	fdt_enforce_memory_region();
++
+ 	/*
+ 	 * Ensure that the linear region takes up exactly half of the kernel
+ 	 * virtual address space. This way, we can distinguish a linear address
+-- 
+2.31.1
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0003-arm64-kdump-reserve-memory-for-crash-dump-kernel.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0003-arm64-kdump-reserve-memory-for-crash-dump-kernel.patch
@@ -1,0 +1,151 @@
+From b47b8edcee204ec11320d86ed2a32ea9a01cdec0 Mon Sep 17 00:00:00 2001
+From: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Date: Mon, 3 Apr 2017 11:24:32 +0900
+Subject: [PATCH 3/3] arm64: kdump: reserve memory for crash dump kernel
+
+"crashkernel=" kernel parameter specifies the size (and optionally
+the start address) of the system ram to be used by crash dump kernel.
+reserve_crashkernel() will allocate and reserve that memory at boot time
+of primary kernel.
+
+The memory range will be exposed to userspace as a resource named
+"Crash kernel" in /proc/iomem.
+
+Signed-off-by: AKASHI Takahiro <takahiro.akashi@linaro.org>
+Signed-off-by: Mark Salter <msalter@redhat.com>
+Signed-off-by: Pratyush Anand <panand@redhat.com>
+Reviewed-by: James Morse <james.morse@arm.com>
+Acked-by: Catalin Marinas <catalin.marinas@arm.com>
+Reviewed-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Signed-off-by: Catalin Marinas <catalin.marinas@arm.com>
+---
+ arch/arm64/kernel/setup.c |  7 ++++-
+ arch/arm64/mm/init.c      | 66 +++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 72 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/kernel/setup.c b/arch/arm64/kernel/setup.c
+index cb26694df7f6..facae6e06e1e 100644
+--- a/arch/arm64/kernel/setup.c
++++ b/arch/arm64/kernel/setup.c
+@@ -31,7 +31,6 @@
+ #include <linux/screen_info.h>
+ #include <linux/init.h>
+ #include <linux/kexec.h>
+-#include <linux/crash_dump.h>
+ #include <linux/root_dev.h>
+ #include <linux/cpu.h>
+ #include <linux/interrupt.h>
+@@ -225,6 +224,12 @@ static void __init request_standard_resources(void)
+ 		if (kernel_data.start >= res->start &&
+ 		    kernel_data.end <= res->end)
+ 			request_resource(res, &kernel_data);
++#ifdef CONFIG_KEXEC_CORE
++		/* Userspace will find "Crash kernel" region in /proc/iomem. */
++		if (crashk_res.end && crashk_res.start >= res->start &&
++		    crashk_res.end <= res->end)
++			request_resource(res, &crashk_res);
++#endif
+ 	}
+ }
+ 
+diff --git a/arch/arm64/mm/init.c b/arch/arm64/mm/init.c
+index 794780886b22..a77f7a1dfd5a 100644
+--- a/arch/arm64/mm/init.c
++++ b/arch/arm64/mm/init.c
+@@ -30,6 +30,7 @@
+ #include <linux/gfp.h>
+ #include <linux/memblock.h>
+ #include <linux/sort.h>
++#include <linux/of.h>
+ #include <linux/of_fdt.h>
+ #include <linux/dma-mapping.h>
+ #include <linux/dma-contiguous.h>
+@@ -37,6 +38,7 @@
+ #include <linux/swiotlb.h>
+ #include <linux/vmalloc.h>
+ #include <linux/mm.h>
++#include <linux/kexec.h>
+ 
+ #include <asm/boot.h>
+ #include <asm/fixmap.h>
+@@ -77,6 +79,67 @@ static int __init early_initrd(char *p)
+ early_param("initrd", early_initrd);
+ #endif
+ 
++#ifdef CONFIG_KEXEC_CORE
++/*
++ * reserve_crashkernel() - reserves memory for crash kernel
++ *
++ * This function reserves memory area given in "crashkernel=" kernel command
++ * line parameter. The memory reserved is used by dump capture kernel when
++ * primary kernel is crashing.
++ */
++static void __init reserve_crashkernel(void)
++{
++	unsigned long long crash_base, crash_size;
++	int ret;
++
++	ret = parse_crashkernel(boot_command_line, memblock_phys_mem_size(),
++				&crash_size, &crash_base);
++	/* no crashkernel= or invalid value specified */
++	if (ret || !crash_size)
++		return;
++
++	crash_size = PAGE_ALIGN(crash_size);
++
++	if (crash_base == 0) {
++		/* Current arm64 boot protocol requires 2MB alignment */
++		crash_base = memblock_find_in_range(0, ARCH_LOW_ADDRESS_LIMIT,
++				crash_size, SZ_2M);
++		if (crash_base == 0) {
++			pr_warn("cannot allocate crashkernel (size:0x%llx)\n",
++				crash_size);
++			return;
++		}
++	} else {
++		/* User specifies base address explicitly. */
++		if (!memblock_is_region_memory(crash_base, crash_size)) {
++			pr_warn("cannot reserve crashkernel: region is not memory\n");
++			return;
++		}
++
++		if (memblock_is_region_reserved(crash_base, crash_size)) {
++			pr_warn("cannot reserve crashkernel: region overlaps reserved memory\n");
++			return;
++		}
++
++		if (!IS_ALIGNED(crash_base, SZ_2M)) {
++			pr_warn("cannot reserve crashkernel: base address is not 2MB aligned\n");
++			return;
++		}
++	}
++	memblock_reserve(crash_base, crash_size);
++
++	pr_info("crashkernel reserved: 0x%016llx - 0x%016llx (%lld MB)\n",
++		crash_base, crash_base + crash_size, crash_size >> 20);
++
++	crashk_res.start = crash_base;
++	crashk_res.end = crash_base + crash_size - 1;
++}
++#else
++static void __init reserve_crashkernel(void)
++{
++}
++#endif /* CONFIG_KEXEC_CORE */
++
+ /*
+  * Return the maximum physical address for ZONE_DMA (DMA_BIT_MASK(32)). It
+  * currently assumes that for memory starting above 4G, 32-bit devices will
+@@ -336,6 +399,9 @@ void __init arm64_memblock_init(void)
+ 		arm64_dma_phys_limit = max_zone_dma_phys();
+ 	else
+ 		arm64_dma_phys_limit = PHYS_MASK + 1;
++
++	reserve_crashkernel();
++
+ 	high_memory = __va(memblock_end_of_DRAM() - 1) + 1;
+ 	dma_contiguous_reserve(arm64_dma_phys_limit);
+ 
+-- 
+2.31.1
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -18,6 +18,14 @@ SRC_URI_append = " \
     file://xhci-ring-Don-t-show-incorrect-WARN-message-about.patch \
 "
 
+# Patches pulled from upstream for crashkernel memory reservation
+# c9ca9b4..764b51e (last patch required minor modifications)
+SRC_URI_append = " \
+    file://0001-memblock-add-memblock_cap_memory_range.patch \
+    file://0002-arm64-limit-memory-regions-based-on-DT-property-usab.patch \
+    file://0003-arm64-kdump-reserve-memory-for-crash-dump-kernel.patch \
+    "
+
 SRC_URI_append_jetson-tx2 = " \
     file://0001-Expose-spidev-to-the-userspace.patch \
     file://0002-mttcan-ivc-enable.patch \
@@ -72,6 +80,13 @@ SRC_URI_append_photon-xavier-nx = " \
 "
 
 TEGRA_INITRAMFS_INITRD = "0"
+
+BALENA_CONFIGS_append = " kdump"
+
+BALENA_CONFIGS[kdump] = " \
+    CONFIG_KEXEC=y \
+    CONFIG_SYSFS=y \
+    "
 
 BALENA_CONFIGS_append = " tegra-wdt-t21x debug_kmemleak "
 


### PR DESCRIPTION
Backport patches from linux v4.12 for enabling memory reservation for
crash kernel on arm64, and enable configs necessary for loading a crash
kernel.

Signed-off-by: Joseph Kogut <joseph@balena.io>