### PR TITLE
linux-tegra: disable panic on hung task

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -79,6 +79,14 @@ BALENA_CONFIGS[tegra-wdt-t21x] = " \
     CONFIG_TEGRA21X_WATCHDOG=m \
 "
 
+# The kernel can detect tasks with high iowait as hung, when they're just
+# waiting for a slow disk, causing a panic/reboot with nvidia's defconfig.
+BALENA_CONFIGS_append = " disable_hung_panic"
+
+BALENA_CONFIGS[disable_hung_panic] = " \
+    CONFIG_BOOTPARAM_HUNG_TASK_PANIC=n \
+    "
+
 BALENA_CONFIGS[debug_kmemleak] = " \
     CONFIG_HAVE_DEBUG_KMEMLEAK=n \
     CONFIG_DEBUG_KMEMLEAK=n \


### PR DESCRIPTION
Nvidia's tegra_defconfig enables CONFIG_BOOTPARAM_HUNG_TASK_PANIC which
can trigger panics upon high iowait, such as balena-engine
downloading/writing a large image to disk.

Kconfig says the following:

    Say Y here to enable the kernel to panic on "hung tasks",
    which are bugs that cause the kernel to leave a task stuck
    in uninterruptible "D" state.

    The panic can be used in combination with panic_timeout,
    to cause the system to reboot automatically after a
    hung task has been detected. This feature is useful for
    high-availability systems that have uptime guarantees and
    where a hung tasks must be resolved ASAP.

    Say N if unsure.

Hung tasks are not normally terminal, nor do they affect system
stability, but panicking during an image write forces a device into a
bootloop that requires manual intervention to remedy.

See the below stacktrace:

    [  243.565482] INFO: task balenad:4049 blocked for more than 120 seconds.
    [  243.565737]       Not tainted 4.9.140-l4t-r32.4 #1
    [  243.565853] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
    [  243.566032] balenad         D    0  4049      1 0x00000008
    [  243.566236] Call trace:
    [  243.566354] [<ffffff80080863a4>] __switch_to+0x9c/0xc0
    [  243.566479] [<ffffff8008f0d09c>] __schedule+0x22c/0x570
    [  243.566590] [<ffffff8008f0d420>] schedule+0x40/0xa8
    [  243.566744] [<ffffff8008f1057c>] rwsem_down_read_failed+0xd4/0x128
    [  243.566872] [<ffffff8008f0f8a8>] down_read+0x58/0x60
    [  243.566999] [<ffffff8008263568>] iterate_supers+0x78/0x138
    [  243.567131] [<ffffff800829bac0>] sys_sync+0x50/0xc0
    [  243.567237] [<ffffff8008083900>] el0_svc_naked+0x34/0x38
    [  243.567394] Kernel panic - not syncing: hung_task: blocked tasks
    [  243.567533] CPU: 3 PID: 47 Comm: khungtaskd Not tainted 4.9.140-l4t-r32.4 #1
    [  243.567819] Hardware name: NVIDIA Jetson Xavier NX Developer Kit (DT)
    [  243.568318] Call trace:
    [  243.568508] [<ffffff800808c678>] dump_backtrace+0x0/0x1a8
    [  243.571026] [<ffffff800808c844>] show_stack+0x24/0x30
    [  243.576195] [<ffffff800841f4e8>] dump_stack+0x94/0xbc
    [  243.581446] [<ffffff80081c3db0>] panic+0x128/0x28c
    [  243.586599] [<ffffff8008178190>] watchdog+0x2f8/0x398
    [  243.591760] [<ffffff80080dcd60>] kthread+0x100/0x108
    [  243.596477] [<ffffff80080838a0>] ret_from_fork+0x10/0x30
    [  243.602257] SMP: stopping secondary CPUs
    [  243.605897] Kernel Offset: disabled
    [  243.609511] Memory Limit: none
    [  243.612484] trusty-log panic notifier - trusty version Built: 12:18:19 Oct 16 2020 [  243.636124] Rebooting in 1 seconds..

Disable this config by default.

Related issue: https://github.com/balena-os/balena-jetson/issues/166

Signed-off-by: Joseph Kogut <joseph@balena.io>