### PR TITLE
[WIP] Nano generate bootblob for 32.4.4

### DIFF
--- a/layers/meta-balena-jetson/conf/machine/jn30b-nano.conf
+++ b/layers/meta-balena-jetson/conf/machine/jn30b-nano.conf
@@ -5,3 +5,5 @@
 MACHINEOVERRIDES = "jetson-nano-emmc:${MACHINE}"
 require conf/machine/jetson-nano-emmc.conf
 
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':jetson-nano-emmc:${MACHINE}')}"
+

--- a/layers/meta-balena-jetson/conf/machine/photon-nano.conf
+++ b/layers/meta-balena-jetson/conf/machine/photon-nano.conf
@@ -5,6 +5,8 @@
 MACHINEOVERRIDES = "jetson-nano-emmc:${MACHINE}"
 require conf/machine/jetson-nano-emmc.conf
 
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':jetson-nano-emmc:${MACHINE}')}"
+
 # Fix for some PCIe wifi adapters that do not work with the default ASPM
 # 'powersave' policy.
 KERNEL_ARGS_append = " pcie_aspm.policy=performance"

--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/files/resinOS-flash210.xml
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/files/resinOS-flash210.xml
@@ -64,8 +64,7 @@
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
         </partition>
-
-        <partition name="TBC" id="9" type="TBCTYPE">
+        <partition name="TBC" id="8" type="TBCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072</size>
@@ -75,7 +74,7 @@
             <filename> TBCFILE </filename>
         </partition>
 
-        <partition name="RP1" id="10" type="data">
+        <partition name="RP1" id="9" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
@@ -85,7 +84,7 @@
             <filename> DTBFILE </filename>
         </partition>
 
-        <partition name="EBT" id="11" type="bootloader">
+        <partition name="EBT" id="10" type="bootloader">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 589824 </size>
@@ -95,7 +94,7 @@
             <filename> EBTFILE </filename>
         </partition>
 
-        <partition name="WB0" id="12" type="WB0TYPE">
+        <partition name="WB0" id="11" type="WB0TYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -105,7 +104,7 @@
             <filename> WB0FILE </filename>
         </partition>
 
-        <partition name="BPF" id="13" type="data">
+        <partition name="BPF" id="12" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -116,27 +115,7 @@
             <filename> BPFFILE </filename>
         </partition>
 
-        <partition name="BPF-DTB" id="14" type="data">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 393216 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 8 </allocation_attribute>
-            <percent_reserved> 0 </percent_reserved>
-            <filename> BPFDTB-FILE </filename>
-        </partition>
-
-        <partition name="FX" id="15" type="FBTYPE">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 65536 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
-            <percent_reserved> 0 </percent_reserved>
-            <filename> FBFILE </filename>
-        </partition>
-
-        <partition name="TOS" id="16" type="data">
+        <partition name="TOS" id="13" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
@@ -146,28 +125,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> TOSFILE </filename>
         </partition>
-
-        <partition name="DTB" id="17" type="data">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 458752 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
-            <percent_reserved> 0 </percent_reserved>
-            <filename> DTBFILE </filename>
-        </partition>
-
-        <partition name="LNX" id="18" type="data">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 786432 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
-            <percent_reserved> 0 </percent_reserved>
-            <filename> u-boot.bin </filename>
-        </partition>
-
-        <partition name="EXS" id="19" type="data">
+        <partition name="EXS" id="14" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -177,18 +135,26 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> EKSFILE </filename>
         </partition>
-
-        <partition name="BMP" id="20" type="data">
+        <partition name="LNX" id="15" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 81920 </size>
+            <size> 786432 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> bmp.blob </filename>
+            <filename> u-boot.bin </filename>
+        </partition>
+        <partition name="DTB" id="16" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTBFILE </filename>
         </partition>
 
-        <partition name="RP4" id="21" type="data">
+        <partition name="RP4" id="17" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -197,7 +163,16 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> rp4.blob </filename>
         </partition>
-     <partition id="22" name="resin-boot" type="data">
+        <partition name="BMP" id="18" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 46971904 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+        </partition>
+     <partition id="19" name="resin-boot" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 83886080 </size>
@@ -206,34 +181,34 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> resin-boot.img </filename>
         </partition>
-        <partition id="23" name="resin-rootA" type="data">
+        <partition id="20" name="resin-rootA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 499122176 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> resin-rootA.img </filename>
         </partition>
-        <partition id="24" name="resin-rootB" type="data">
+        <partition id="21" name="resin-rootB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 499122176 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> resin-rootB.img </filename>
         </partition>
-        <partition id="25" name="resin-state" type="data">
+        <partition id="22" name="resin-state" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 20971520 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> resin-state.img </filename>
         </partition>
-        <partition id="26" name="resin-data" type="data">
+        <partition id="23" name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2019122176 </size>
@@ -242,8 +217,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename>resin-data.img</filename>
         </partition>
-
-        <partition name="GPT" id="22" type="GPT">
+        <partition name="GPT" id="24" type="GPT">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>

--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -121,6 +121,7 @@ IMAGE_PACKAGES_NANO = " \
     tegra-configs-nvstartup \
     tegra-configs-udev \
     jetson-dtbs \
+    mtd-utils \
 "
 
 IMAGE_INSTALL_append_jetson-nano = "${IMAGE_PACKAGES_NANO}"

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
@@ -4,19 +4,31 @@ set -o errexit
 
 . /usr/libexec/os-helpers-fs
 
-bootfiles=$(ls /resin-boot/bootfiles/);
+QSPI="/dev/mtd0"
+BOOTLOADER_DEVICE="/dev/mtdblock0"
 
 info_log()
 {
     echo "[INFO] $@"
 }
 
+# Jetson Nano SD has a qspi-nor,
+# Jetson Nano eMMC doesn't.
+if [ ! -e "${BOOTLOADER_DEVICE}" ]; then
+    info_log "This Nano module does not have a QSPI NOR, using hardware partition for boot blob"
+    BOOTLOADER_DEVICE="/dev/mmcblk0boot0"
+fi
+
+BIN_INSTALL_PATH="/opt/tegra-binaries"
+BOOT_BLOB="${BIN_INSTALL_PATH}/boot0.img"
+PART_SPEC="${BIN_INSTALL_PATH}/partition_specification210.txt"
+
 update_needed() {
     current_update_file=${1}
     device=${2}
     update_size=$(ls -al $current_update_file | awk '{print $5}')
     update_md5sum=$(md5sum $current_update_file | awk '{print $1'})
-    existing_md5sum=$(dd if=$device bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
+    existing_md5sum=$(dd if=$device bs=$update_size count=1 status=none | md5sum | awk '{print $1}')
 
     if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
         echo 1
@@ -25,18 +37,41 @@ update_needed() {
     fi
 }
 
-for bootfile in ${bootfiles}
-do
-    src="/resin-boot/bootfiles/$bootfile"
-    dst=$(get_state_path_from_label "$bootfile")
+partitions=$(cat "${PART_SPEC}")
+for n in ${partitions}; do
+    part_name=$(echo $n | cut -d ':' -f 1)
+    file_name=$(echo $n | cut -d ':' -f 2)
+
+    file_path=$(get_state_path_from_label $part_name)
+
+    if [ "x$file_path" = "x" ]; then
+        continue
+    fi
+
+    src="${BIN_INSTALL_PATH}/$file_name"
+    dst="$file_path"
 
     if [ $(update_needed $src $dst) -eq 1 ]; then
         info_log "Will update ${dst}..."
-        dd if=${src} of=${dst} bs=1K
-        info_log "Updated ${dst}"
+        dd if=${src} of=${dst}
     else
         info_log "No need to update ${dst}"
     fi
 done
+
+existing_bootloader_md5sum=$(dd if=${BOOTLOADER_DEVICE} bs=1M status=none | md5sum | awk '{print $1}')
+update_bootloader_md5sum=$(md5sum ${BOOT_BLOB} | awk '{print $1}')
+
+if [ ! "$existing_bootloader_md5sum" = "$update_bootloader_md5sum" ]; then
+    info_log "Will update bootloader device ${BOOTLOADER_DEVICE}"
+    if [ -e "${QSPI}" ]; then
+        flash_erase ${QSPI} 0 0 || true
+    else
+        echo 0 > /sys/block/mmcblk0boot0/force_ro
+    fi
+    dd if=${BOOT_BLOB} of=${BOOTLOADER_DEVICE} bs=1M || true
+else
+    info_log "No need to update bootloader device"
+fi
 
 sync

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-nano
@@ -21,7 +21,7 @@ fi
 
 BIN_INSTALL_PATH="/opt/tegra-binaries"
 BOOT_BLOB="${BIN_INSTALL_PATH}/boot0.img"
-PART_SPEC="${BIN_INSTALL_PATH}/partition_specification210.txt"
+PART_SPEC=$(find "${BIN_INSTALL_PATH}" | grep partition_specification210 | grep txt | head -n 1)
 
 update_needed() {
     current_update_file=${1}

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit
@@ -96,7 +96,7 @@ update_bootloader_md5sum=$(md5sum $bootloader_blob | awk '{print $1}')
 
 if [ ! "$existing_bootloader_md5sum" = "$update_bootloader_md5sum" ]; then
     info_log "Will update bootloader device"
-    flash_erase /dev/mtd0 0 0
+    flash_erase /dev/mtd0 0 0 || true
     dd if=$bootloader_blob of=$bootloader_device bs=1M
 else
     info_log "No need to update bootloader device"


### PR DESCRIPTION
This is a WIP PR and it currently only covers the Nano SD and Nano eMMC modules boot blob stored either on the qspi-nor or on the emmc hw partition.
Addresses: https://github.com/balena-os/balena-jetson/issues/170