### PR TITLE
meta-balena-jetson: libnvidia-container-tools: Fix fetch for nvidia-m…

### DIFF
--- a/layers/meta-balena-jetson/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
+++ b/layers/meta-balena-jetson/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
@@ -34,7 +34,7 @@ ELF_TOOLCHAIN_VERSION = "0.7.1"
 LIBTIRPC_VERSION = "1.1.4"
 
 SRC_URI = "git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia;branch=jetson \
-           git://github.com/NVIDIA/nvidia-modprobe.git;name=modprobe;destsuffix=git/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} \
+           git://github.com/NVIDIA/nvidia-modprobe.git;name=modprobe;branch=main;destsuffix=git/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} \
            file://0001-Makefile-Fix-RCP-flags-and-change-path-definitions-s.patch \
            file://0002-common.mk-Set-JETSON-variable-if-not-set-before.patch \
            file://0003-Fix-mapping-of-library-paths-for-jetson-mounts.patch \


### PR DESCRIPTION
…odprobe

The upstream recipe has removed the master branch and replaced it with
main. When specifying the SRC_URI with a sha1, the OE fetcher will assume
the master branch and fail with:

libnvidia-container-tools-0.9.0-r1 do_fetch: Fetcher failure: Unable to find revision d97c08af5061f1516fb2e3a26508936f69d6d71d in branch master even from upstream

This commit specifies the upstream branch as main.

Change-type: patch
Changelog-entry: Fix the upstream branch for nvidia-modprobe
Signed-off-by: Alex Gonzalez <alexg@balena.io>