### PR TITLE
linux-firmware: drop temporary fw update changes

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,8 +1,1 @@
-SRCREV_jetson-tx2 = "0dd245d3691f99c87be5d0373625960e545b6493"
-
-LIC_FILES_CHKSUM_remove_jetson-tx2 = " file://LICENSE.amdgpu;md5=ab515ef6495ab5c5a3b08ab2db62df11 "
-LIC_FILES_CHKSUM_append_jetson-tx2 = " file://LICENSE.amdgpu;md5=d357524f5099e2a3db3c1838921c593f "
-LIC_FILES_CHKSUM_remove_jetson-tx2 = " file://WHENCE;md5=37a01e379219d1e06dbccfa90a8fc0ad"
-LIC_FILES_CHKSUM_append_jetson-tx2 = " file://WHENCE;md5=82646834b0076777ae0b2747fe306869 "
-
 IWLWIFI_FW_MIN_API[8265] = "22"


### PR DESCRIPTION
These were needed to deliver an urgent OS image,
now meta-balena updates the firmware recipe so
we can drop these changes.

This reverts commit e96dc8e because it is no longer
necessary.

Changelog-entry: linux-firmware: drop temporary fw update changes
Signed-off-by: Alexandru Costache <alexandru@balena.io>