### PR TITLE
Release v2.82.8

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,5 +1,4 @@
 PACKAGE_INSTALL_append = " tegra-firmware-xusb"
-PACKAGE_INSTALL_append_jetson-tx2 = " kernel-module-bcmdhd"
 
 # Because of https://github.com/balena-os/balena-jetson/issues/90
 # the TX1 does not have a 32.X release currently. Let's decrease

--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -178,6 +178,7 @@ IMAGE_INSTALL_append_jetson-tx2 = " \
     tegra-firmware-xusb \
     bt-scripts \
     jetson-dtbs \
+    kernel-module-bcmdhd \
 "
 
 IMAGE_INSTALL_append_jetson-tx1 = " \

--- a/layers/meta-balena-jetson/recipes-core/initrdscripts/files/governor
+++ b/layers/meta-balena-jetson/recipes-core/initrdscripts/files/governor
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+governor_enabled() {
+    return 0
+}
+
+governor_run() {
+    # See: https://forums.developer.nvidia.com/t/cannot-enable-denver-cores-for-tx2-jetpack-4-4-dp/124708/44
+    echo 0 > /sys/devices/system/cpu/cpu1/online || true
+    echo 0 > /sys/devices/system/cpu/cpu2/online || true
+    echo "performance" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor || true
+}

--- a/layers/meta-balena-jetson/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -40,3 +40,20 @@ PACKAGES_append_jetson-xavier-nx-devkit = " \
 # to populate /dev with emmc partitions
 SUMMARY_initramfs-module-blockdev = "Trigger ioctl to force re-read emmc partitions"
 FILES_initramfs-module-blockdev = "/init.d/02-blockdev"
+
+
+SRC_URI_append = " \
+    file://governor \
+"
+
+do_install_append_() {
+    install -m 0755 ${WORKDIR}/governor ${D}/init.d/01-governor
+}
+
+
+PACKAGES_append = " \
+    initramfs-module-governor \
+"
+
+SUMMARY_initramfs-module-governor = "Set arm cores governor to performance"
+FILES_initramfs-module-governor = "/init.d/01-governor"

--- a/layers/meta-balena-jetson/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,1 +1,8 @@
+SRCREV_jetson-tx2 = "0dd245d3691f99c87be5d0373625960e545b6493"
+
+LIC_FILES_CHKSUM_remove_jetson-tx2 = " file://LICENSE.amdgpu;md5=ab515ef6495ab5c5a3b08ab2db62df11 "
+LIC_FILES_CHKSUM_append_jetson-tx2 = " file://LICENSE.amdgpu;md5=d357524f5099e2a3db3c1838921c593f "
+LIC_FILES_CHKSUM_remove_jetson-tx2 = " file://WHENCE;md5=37a01e379219d1e06dbccfa90a8fc0ad"
+LIC_FILES_CHKSUM_append_jetson-tx2 = " file://WHENCE;md5=82646834b0076777ae0b2747fe306869 "
+
 IWLWIFI_FW_MIN_API[8265] = "22"

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-dont-export-rpmb-as-part.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-dont-export-rpmb-as-part.patch
@@ -1,0 +1,39 @@
+From 26485ed0fe8a488eb0793a7417cc878eb837dac0 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Sun, 4 Jul 2021 16:49:04 +0200
+Subject: [PATCH] dont export rpmb as partition
+
+We get a few warnings when udev tries to open
+mmcblk0rpmb, let's not expose this as a partition
+since it's not necessary for our configuration and
+it might speed up boot by a few hundred ms.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ drivers/mmc/core/mmc.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/mmc/core/mmc.c b/drivers/mmc/core/mmc.c
+index 75cdd8528e5d..facb096323f2 100644
+--- a/drivers/mmc/core/mmc.c
++++ b/drivers/mmc/core/mmc.c
+@@ -566,6 +566,7 @@ static int mmc_decode_ext_csd(struct mmc_card *card, u8 *ext_csd)
+ 		card->ext_csd.rel_param = ext_csd[EXT_CSD_WR_REL_PARAM];
+ 		card->ext_csd.rst_n_function = ext_csd[EXT_CSD_RST_N_FUNCTION];
+ 
++#if 0
+ 		/*
+ 		 * RPMB regions are defined in multiples of 128K.
+ 		 */
+@@ -576,6 +577,7 @@ static int mmc_decode_ext_csd(struct mmc_card *card, u8 *ext_csd)
+ 				"rpmb", 0, false,
+ 				MMC_BLK_DATA_AREA_RPMB);
+ 		}
++#endif		
+ 	}
+ 
+ 	card->ext_csd.raw_erased_mem_count = ext_csd[EXT_CSD_ERASED_MEM_CONT];
+-- 
+2.17.1
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -16,6 +16,7 @@ SRC_URI_append = " \
     file://0001-revert-random-fix-crng_ready-test.patch \
     file://0001-Support-referencing-the-root-partition-label-from-GP.patch \
     file://xhci-ring-Don-t-show-incorrect-WARN-message-about.patch \
+    file://0001-dont-export-rpmb-as-part.patch \
 "
 SRC_URI_append_jetson-tx2 = " \
     file://0001-Expose-spidev-to-the-userspace.patch \

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -17,6 +17,7 @@ SRC_URI_append = " \
     file://0001-Support-referencing-the-root-partition-label-from-GP.patch \
     file://xhci-ring-Don-t-show-incorrect-WARN-message-about.patch \
     file://0001-dont-export-rpmb-as-part.patch \
+    file://0002-qmi_wwan-Update-from-4.14-kernel.patch \
 "
 SRC_URI_append_jetson-tx2 = " \
     file://0001-Expose-spidev-to-the-userspace.patch \
@@ -27,7 +28,6 @@ SRC_URI_append_jetson-tx2 = " \
     file://tegra186-tx2-cti-ASG006-IMX274-6CAM.dtb \
     file://tegra186-tx2-blackboard.dtb \
     file://realsense_powerlinefrequency_control_fix_linux-yocto_4.4.patch \
-    file://0002-qmi_wwan-Update-from-4.14-kernel.patch \
     file://0001-mttcan_ivc-Fix-build-failure-with-kernel-4.9.patch \
     file://0001-gasket-Backport-gasket-driver-from-linux-coral.patch \
 "


### PR DESCRIPTION
Commit https://github.com/balena-os/balena-jetson/pull/195/commits/338c6eacdf40cf9618b7659bd31882dc58bbefcd adds backported qmi_wwan patches to all boards in this repository - related to https://github.com/balena-os/balena-jetson/issues/178.