### PR TITLE
jetson-tx2-nx-devkit: Specify actual boot partition index

### DIFF
--- a/jetson-tx2-nx-devkit.coffee
+++ b/jetson-tx2-nx-devkit.coffee
@@ -38,7 +38,7 @@ module.exports =
 	configuration:
 		config:
 			partition:
-				primary: 1
+				primary: 24
 			path: '/config.json'
 
 	initialization: commonImg.initialization


### PR DESCRIPTION
Unlike the TX2, the TX2 NX does not have a flasher image,
which means the boot partition is not the first one in the
table. Set the index to 24 so that the image-maker knows
where to place the configuration files.

Changelog-entry: jetson-tx2-nx-devkit: Specify actual boot partition index
Signed-off-by: Alexandru Costache <alexandru@balena.io>