### PR TITLE
balena-yocto-scripts: Update to v1.14.8

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-nxde-flash-dry_32.5.1.bb
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-nxde-flash-dry_32.5.1.bb
@@ -340,7 +340,8 @@ do_configure() {
     #dd if=${DEPLOY_DIR_IMAGE}/bootfiles/cbo.dtb seek=33226752 bs=1 conv=notrunc
 
     # For 32.5.1 /opt/tegra-binaries/boot0.img MD5 should have the same MD5
-    # even for carrier boards. If it isn't then board won't boot after HUP.
+    # even if building the image for compatible carrier boards. If it isn't identical,
+    # then the device won't boot after HUP.
     cp ${WORKDIR}/${BOOT_BINDIFF} .
     dd if=${BOOT_BINDIFF} of=boot0.img seek=14942224 bs=1 count=32 conv=notrunc
     dd if=${BOOT_BINDIFF} of=boot0.img seek=14945200 skip=32  bs=1 count=80 conv=notrunc

--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-nxde-sdcard-flash_32.5.1.bb
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-nxde-sdcard-flash_32.5.1.bb
@@ -338,7 +338,8 @@ do_configure() {
     #dd if=${DEPLOY_DIR_IMAGE}/bootfiles/cbo.dtb seek=33226752 bs=1 conv=notrunc
 
     # For 32.5.1 /opt/tegra-binaries/boot0.img MD5 should have the same MD5
-    # even for carrier boards. If it isn't then board won't boot after HUP.
+    # even if building images for compatible carrier boards. If it isn't identical,
+    # then board won't boot after HUP.
     cp ${WORKDIR}/${BOOT_BINDIFF} .
     dd if=${BOOT_BINDIFF} of=boot0.img seek=14942224 bs=1 count=32 conv=notrunc
     dd if=${BOOT_BINDIFF} of=boot0.img seek=14945200 skip=32  bs=1 count=80 conv=notrunc

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit
@@ -102,6 +102,7 @@ else
     info_log "No need to update bootloader device"
 fi
 
-sync
+# Sync internal memory
+sync /dev/mmcblk0
 
 info_log "Done."


### PR DESCRIPTION
Update balena-yocto-scripts from 1.14.7 to 1.14.8
    
Changelog-entry: Update balena-yocto-scripts from v1.14.7 to v1.14.8
Signed-off-by: Alexandru Costache <alexandru@balena.io>

We also fixed config.json placing in the last build for the tx2 nx so now we need a new image deploy for testing dashboard
triggered hup on this new device release. We'll use this PR for that.