### PR TITLE
Jets Xavier-based boards: switch between A/B slots during HUP

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/tools/files/0001-switch-retry-count-to-3.patch
+++ b/layers/meta-balena-jetson/recipes-bsp/tools/files/0001-switch-retry-count-to-3.patch
@@ -1,0 +1,94 @@
+From 0d51d59ac122cbd4bbdaed8d9287eb17fc30e1cb Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Mon, 23 Aug 2021 18:21:33 +0200
+Subject: [PATCH] switch retry count to 3
+
+By default the boot retry count in the scratch
+register is set to 7 but in BalenaOS it is set to 3,
+so let's keep the default BalenaOS value.
+
+Upstream-status: Inappropriate[configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ smd.c | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/smd.c b/smd.c
+index 60c1e76..af83ce6 100644
+--- a/smd.c
++++ b/smd.c
+@@ -15,6 +15,8 @@
+ #include <zlib.h>
+ #include "smd.h"
+ 
++#define BALENA_BOOT_RETRY_COUNT 3
++
+ /*
+  * Structures used in the SMD storage
+  */
+@@ -203,7 +205,7 @@ smd_new (smd_redundancy_level_t level)
+ 	ctx->smd_ods.smd.slot_info[0].priority = 15;
+ 	ctx->smd_ods.smd.slot_info[0].suffix[0] = ctx->suffixes[0][0];
+ 	ctx->smd_ods.smd.slot_info[0].suffix[1] = ctx->suffixes[0][1];
+-	ctx->smd_ods.smd.slot_info[0].retry_count = 7;
++	ctx->smd_ods.smd.slot_info[0].retry_count = BALENA_BOOT_RETRY_COUNT;
+ 	ctx->smd_ods.smd.slot_info[0].successful = 1;
+ 	if (smd_set_redundancy_level(ctx, level) != 0) {
+ 		free(ctx);
+@@ -287,7 +289,7 @@ smd_set_redundancy_level (smd_context_t *ctx, smd_redundancy_level_t level)
+ 		ctx->smd_ods.smd.flags &= ~3U;
+ 		ctx->smd_ods.smd.maxslots = 1;
+ 		ctx->smd_ods.smd.slot_info[0].priority = 15;
+-		ctx->smd_ods.smd.slot_info[0].retry_count = 7;
++		ctx->smd_ods.smd.slot_info[0].retry_count = BALENA_BOOT_RETRY_COUNT;
+ 		ctx->smd_ods.smd.slot_info[0].successful = 1;
+ 		memset(&ctx->smd_ods.smd.slot_info[1], 0, sizeof(ctx->smd_ods.smd.slot_info[1]));
+ 		break;
+@@ -315,7 +317,7 @@ smd_set_redundancy_level (smd_context_t *ctx, smd_redundancy_level_t level)
+ 				s->priority = 15 - i;
+ 				s->suffix[0] = ctx->suffixes[i][0];
+ 				s->suffix[1] = ctx->suffixes[i][1];
+-				s->retry_count = 7;
++				s->retry_count = BALENA_BOOT_RETRY_COUNT;
+ 				s->successful = 1;
+ 			}
+ 		}
+@@ -429,11 +431,11 @@ smd_slot_mark_successful (smd_context_t *ctx, unsigned int which)
+ 
+ 	s = &ctx->smd_ods.smd.slot_info[which];
+ 	other = &ctx->smd_ods.smd.slot_info[1-which];
+-	ctx->needs_update = (s->successful != 1 || s->retry_count != 7 ||
++	ctx->needs_update = (s->successful != 1 || s->retry_count != BALENA_BOOT_RETRY_COUNT ||
+ 			     ((unsigned int) curslot == which &&
+ 			      (s->priority != 15 || other->priority >= s->priority)));
+ 	s->successful = 1;
+-	s->retry_count = 7;
++	s->retry_count = BALENA_BOOT_RETRY_COUNT;
+ 	if ((unsigned int) curslot == which) {
+ 		s->priority = 15;
+ 		if (other->priority >= s->priority)
+@@ -449,7 +451,7 @@ smd_slot_mark_successful (smd_context_t *ctx, unsigned int which)
+  *
+  * Marks a boot slot as active by setting its priority
+  * to 15 and setting the other slot's priority to 14,
+- * resetting its retry count to 7, and marking
++ * resetting its retry count to 1, and marking
+  * it as unsuccessful (so success can be tested after
+  * reboot).
+  *
+@@ -468,10 +470,10 @@ smd_slot_mark_active (smd_context_t *ctx, unsigned int which)
+ 	s = &ctx->smd_ods.smd.slot_info[which];
+ 	ctx->needs_update = (s->priority != 15 ||
+ 			     ctx->smd_ods.smd.slot_info[1-which].priority != 14 ||
+-			     s->retry_count != 7 || s->successful != 0);
++			     s->retry_count != BALENA_BOOT_RETRY_COUNT || s->successful != 0);
+ 	s->priority = 15;
+ 	ctx->smd_ods.smd.slot_info[1-which].priority = 14;
+-	s->retry_count = 7;
++	s->retry_count = BALENA_BOOT_RETRY_COUNT;
+ 	s->successful = 0;
+ 
+ 	return 0;
+-- 
+2.17.1
+

--- a/layers/meta-balena-jetson/recipes-bsp/tools/files/active_slot_set.conf
+++ b/layers/meta-balena-jetson/recipes-bsp/tools/files/active_slot_set.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPre=/bin/bash -c '/usr/bin/tegra-boot-control -e && /usr/bin/tegra-boot-control -m && /usr/bin/tegra-bootinfo -b'
+ExecStartPost=/bin/bash -c '/usr/bin/tegra-boot-control -e && /usr/bin/tegra-boot-control -m && /usr/bin/tegra-bootinfo -b'

--- a/layers/meta-balena-jetson/recipes-bsp/tools/files/active_slot_set.conf
+++ b/layers/meta-balena-jetson/recipes-bsp/tools/files/active_slot_set.conf
@@ -1,3 +1,3 @@
 [Service]
-ExecStartPre=/bin/bash -c '/usr/bin/tegra-boot-control -e && /usr/bin/tegra-boot-control -m && /usr/bin/tegra-bootinfo -b'
-ExecStartPost=/bin/bash -c '/usr/bin/tegra-boot-control -e && /usr/bin/tegra-boot-control -m && /usr/bin/tegra-bootinfo -b'
+ExecStartPre=@BASE_BINDIR@/bash @BINDIR@/set_active_tegra_boot_slot.sh
+ExecStartPost=@BASE_BINDIR@/bash @BINDIR@/set_active_tegra_boot_slot.sh

--- a/layers/meta-balena-jetson/recipes-bsp/tools/files/set_active_tegra_boot_slot.sh
+++ b/layers/meta-balena-jetson/recipes-bsp/tools/files/set_active_tegra_boot_slot.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Ensure reduntant boot is enabled
+if /usr/bin/tegra-boot-control -e ; then
+    echo "Tegra redundant boot: enabled successfully"
+else
+    echo "Tegra redundant boot: failed to enable!"
+fi;
+
+# If the boot process was
+# able to start the rollback service, we can
+# mark the current boot as successful
+if /usr/bin/tegra-boot-control -m ; then
+    echo "Tegra redundant boot: marked successful boot"
+
+    if /usr/bin/tegra-bootinfo -b ; then
+        echo "Tegra redundant boot: recorded successful boot"
+    else
+        echo "Tegra redundant boot: failed to record successful boot"
+    fi
+fi

--- a/layers/meta-balena-jetson/recipes-bsp/tools/tegra-boot-tools_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/tools/tegra-boot-tools_%.bbappend
@@ -1,0 +1,20 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+# libuuid was split from the main
+# util-linux later, after Dunfell
+DEPENDS_remove = "util-linux-libuuid"
+DEPENDS_append = " util-linux"
+
+SRC_URI_append = " \
+	file://0001-switch-retry-count-to-3.patch \
+	file://active_slot_set.conf \
+"
+
+# We use a drop-in and use tegra-boot-tools from it
+# to mark the current slot as ok to boot from. We
+# know it's ok since the service is running, as it
+# wouldn't have been if the kernel crashed.
+do_install_append() {
+    install -d ${D}${sysconfdir}/systemd/system/rollback-altboot.service.d
+    install -m 0644 ${WORKDIR}/active_slot_set.conf ${D}${sysconfdir}/systemd/system/rollback-altboot.service.d/
+}

--- a/layers/meta-balena-jetson/recipes-bsp/tools/tegra-boot-tools_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/tools/tegra-boot-tools_%.bbappend
@@ -8,13 +8,22 @@ DEPENDS_append = " util-linux"
 SRC_URI_append = " \
 	file://0001-switch-retry-count-to-3.patch \
 	file://active_slot_set.conf \
+	file://set_active_tegra_boot_slot.sh \
 "
 
 # We use a drop-in and use tegra-boot-tools from it
 # to mark the current slot as ok to boot from. We
 # know it's ok since the service is running, as it
 # wouldn't have been if the kernel crashed.
+
+# Upon rollback to a release that does not have
+# this feature implemented, the _a slots will
+# be used by default.
 do_install_append() {
     install -d ${D}${sysconfdir}/systemd/system/rollback-altboot.service.d
     install -m 0644 ${WORKDIR}/active_slot_set.conf ${D}${sysconfdir}/systemd/system/rollback-altboot.service.d/
+    install -m 0755 ${WORKDIR}/set_active_tegra_boot_slot.sh ${D}${bindir}/
+    sed -i -e 's,@BINDIR@,${bindir},g' \
+        -e 's,@BASE_BINDIR@,${base_bindir},g' \
+        ${D}${sysconfdir}/systemd/system/rollback-altboot.service.d/active_slot_set.conf
 }

--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -139,6 +139,7 @@ IMAGE_INSTALL_append_jetson-xavier = " \
     tegra-nvpmodel \
     tegra-configs-nvstartup \
     tegra-configs-udev \
+    tegra-boot-tools \
 "
 
 IMAGE_INSTALL_append_jetson-xavier-nx-devkit-emmc = " \
@@ -149,6 +150,7 @@ IMAGE_INSTALL_append_jetson-xavier-nx-devkit-emmc = " \
     tegra-configs-nvstartup \
     tegra-configs-udev \
     mtd-utils \
+    tegra-boot-tools \
 "
 
 IMAGE_INSTALL_append_jetson-xavier-nx-devkit = " \
@@ -164,6 +166,7 @@ IMAGE_INSTALL_append_jetson-xavier-nx-devkit = " \
     tegra-wifi \
     tegra-firmware-rtl8822 \
     tegra-udrm-probeconf \
+    tegra-boot-tools \
 "
 
 IMAGE_INSTALL_append_jetson-tx2 = " \
@@ -182,6 +185,7 @@ IMAGE_INSTALL_append_jetson-tx2 = " \
     jetson-dtbs \
     kernel-module-bcmdhd \
 "
+
 IMAGE_INSTALL_append_jetson-tx2-nx-devkit = " \
     tegra-firmware-rtl8822 \
     kernel-module-rtk-btusb \

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/50-resin-bootfiles-jetson-tx2
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/50-resin-bootfiles-jetson-tx2
@@ -30,6 +30,15 @@ info_log()
     echo "[INFO] $@"
 }
 
+get_label_suffix_by_slot()
+{
+    if [ $1 -eq 0 ]; then
+        echo ''
+    else
+        echo '_b'
+    fi
+}
+
 get_odm_value() {
     odm_off1=$(dd if=${1} skip=${OFFS[0]} bs=1 count=1 status=none | xxd -p)
     odm_off2=$(dd if=${1} skip=${OFFS[1]} bs=1 count=1 status=none | xxd -p)
@@ -52,17 +61,33 @@ set_odm_value() {
 
 update_partition_binaries()
 {
+
+    if ! command -v tegra-boot-control &> /dev/null
+    then
+        info_log "Could not find tegra-boot-control!"
+        exit 1
+    fi
+
+    redundancy_state=$(/usr/bin/tegra-boot-control -s | awk -F 'Redundancy:' '{print $2}' | awk '{print $1}' | tr -d '\n')
+    info_log "Redundancy is currently ${redundancy_state}"
+
+    # Enable boot slot redundancy
+    tegra-boot-control -e
+    curr_slot=$(/usr/bin/tegra-boot-control -c)
+    info_log "New active slot is $((new_slot = ! curr_slot))"
+    new_label_suffix=$(get_label_suffix_by_slot ${new_slot})
+
     for line in $(cat $1); do
         part_name=$(echo $line | cut -d ':' -f 1)
         file_name=$(echo $line | cut -d ':' -f 2)
 	src="${BIN_INSTALL_PATH}/${file_name}"
 	dst=$(get_state_path_from_label  "$part_name")
 	if [ $(update_needed $src $dst) -eq 1 ]; then
-            info_log "Will update ${dst}"
-            dd if=${src} of=${dst} bs=1K
-            info_log "Updated ${dst}"
+            info_log "Will update ${dst}${new_label_suffix} ..."
+            dd if=${src} of="${dst}${new_label_suffix}"
+            info_log "Updated ${dst}${new_label_suffix}"
         else
-            info_log "No need to update ${dst}"
+            info_log "No need to update ${dst}${new_label_suffix}"
         fi
     done
 }
@@ -142,6 +167,14 @@ if [ $(update_needed $src $dst) -eq 1 ]; then
     info_log "Updated $dst"
 else
     info_log "No need to update ${dst}"
+fi
+
+if [ ${UPGRADE_PARTITIONS} -eq 0 ]; then
+   # Update slot selection after the boot memory was updated, otherwise
+   # scratch register contents will be lost.
+   info_log "Setting active slot to ${new_slot}"
+   /usr/bin/tegra-boot-control -e
+   /usr/bin/tegra-boot-control -a "${new_slot}"
 fi
 
 sync

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
@@ -18,6 +18,30 @@ info_log()
 
 info_log "New partition is ${new_part}"
 
+get_label_suffix_by_slot()
+{
+    if [ $1 -eq 0 ]; then
+        echo ''
+    else
+        echo '_b'
+    fi
+}
+
+if ! command -v tegra-boot-control &> /dev/null
+then
+    info_log "Could not find tegra-boot-control!"
+    exit 1
+fi
+
+redundancy_state=$(/usr/bin/tegra-boot-control -s | awk -F 'Redundancy:' '{print $2}' | awk '{print $1}' | tr -d '\n')
+info_log "Redundancy is currently ${redundancy_state}"
+
+# Enable boot slot redundancy
+tegra-boot-control -e
+curr_slot=$(/usr/bin/tegra-boot-control -c)
+info_log "New active slot is $((new_slot = ! curr_slot))"
+new_label_suffix=$(get_label_suffix_by_slot ${new_slot})
+
 rootstr=$(get_dev_label "${new_part}")
 rootl=""
 
@@ -72,25 +96,22 @@ for n in ${partitions}; do
     dst="$file_path"
 
     if [ $(update_needed $src $dst) -eq 1 ]; then
-        info_log "Will update ${dst}..."
-        dd if=${src} of=${dst}
-        dd if=${src} of="${dst}_b"
+        info_log "Will update ${dst}${new_label_suffix} ..."
+        dd if=${src} of="${dst}${new_label_suffix}"
     else
-        info_log "No need to update ${dst}"
+        info_log "No need to update ${dst}${new_label_suffix}"
     fi
 done
 
-# root is contained in the dtb cmdline, needs to be updated to switch rootfs
-info_log "Writing ${dtbfile} to specific partitions..."
-dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "bootloader-dtb")
-dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "bootloader-dtb_b")
-dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "kernel-dtb")
-dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "kernel-dtb_b")
+# root is contained in the dtb cmdline, needs to be updated to switch rootfs, but only in the next active slot
+info_log "Writing ${dtbfile} to specific partitions - suffix is ${new_label_suffix}."
+
+dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "bootloader-dtb${new_label_suffix}")
+dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "kernel-dtb${new_label_suffix}")
 
 info_log "Writing kernel ${kernel} to specific partitions..."
 
-dd if=/resin-boot/bootfiles/${kernel}  of=$(get_state_path_from_label "kernel")
-dd if=/resin-boot/bootfiles/${kernel}  of=$(get_state_path_from_label "kernel_b")
+dd if=/resin-boot/bootfiles/${kernel}  of=$(get_state_path_from_label "kernel${new_label_suffix}")
 
 info_log "Updating boot image on hw partition mmcblk0boot0..."
 
@@ -98,5 +119,11 @@ echo 0 > /sys/block/mmcblk0boot0/force_ro
 dd if=/resin-boot/bootfiles/boot0.img of=/dev/mmcblk0boot0
 sync
 echo 1 > /sys/block/mmcblk0boot0/force_ro
+
+# Update slot selection after the boot memory was updated, otherwise
+# scratch register contents will be lost.
+info_log "Setting active slot to ${new_slot}"
+/usr/bin/tegra-boot-control -e
+/usr/bin/tegra-boot-control -a ${new_slot}
 
 info_log "Done."

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier-nx-devkit
@@ -20,6 +20,30 @@ info_log()
 
 info_log "New partition is ${new_part}"
 
+get_label_suffix_by_slot()
+{
+    if [ $1 -eq 0 ]; then
+        echo ''
+    else
+        echo '_b'
+    fi
+}
+
+if ! command -v tegra-boot-control &> /dev/null
+then
+    info_log "Could not find tegra-boot-control!"
+    exit 1
+fi
+
+redundancy_state=$(/usr/bin/tegra-boot-control -s | awk -F 'Redundancy:' '{print $2}' | awk '{print $1}' | tr -d '\n')
+info_log "Redundancy is currently ${redundancy_state}"
+
+# Enable boot slot redundancy
+tegra-boot-control -e
+curr_slot=$(/usr/bin/tegra-boot-control -c)
+info_log "New active slot is $((new_slot = ! curr_slot))"
+new_label_suffix=$(get_label_suffix_by_slot ${new_slot})
+
 rootstr=$(get_dev_label "${new_part}")
 rootl=""
 
@@ -74,22 +98,19 @@ for n in ${partitions}; do
     dst="$file_path"
 
     if [ $(update_needed $src $dst) -eq 1 ]; then
-        info_log "Will update ${dst} ..."
-        dd if=${src} of=${dst}
-        dd if=${src} of="${dst}_b"
+        info_log "Will update ${dst}${new_label_suffix} ..."
+        dd if=${src} of="${dst}${new_label_suffix}"
     else
-        info_log "No need to update ${dst}"
+        info_log "No need to update ${dst}${new_label_suffix}"
     fi
 done
 
-# DTB contains root partition, update is mandatory
+# DTB contains root partition, update is mandatory on the new boot slot, before switching it to active
 info_log "Writing ${dtbfile} to specific partitions..."
-dd if=/opt/tegra-binaries/${dtbfile} of=$(get_state_path_from_label "kernel-dtb")
-dd if=/opt/tegra-binaries/${dtbfile} of=$(get_state_path_from_label "kernel-dtb_b")
+dd if=/opt/tegra-binaries/${dtbfile} of=$(get_state_path_from_label "kernel-dtb${new_label_suffix}")
 
 info_log "Writing kernel ${kernel} to specific partitions..."
-dd if=/opt/tegra-binaries/${kernel}  of=$(get_state_path_from_label "kernel")
-dd if=/opt/tegra-binaries/${kernel}  of=$(get_state_path_from_label "kernel_b")
+dd if=/opt/tegra-binaries/${kernel} of=$(get_state_path_from_label "kernel${new_label_suffix}")
 
 existing_bootloader_md5sum=$(dd if=$bootloader_device bs=1M status=none | md5sum | awk '{print $1}')
 update_bootloader_md5sum=$(md5sum $bootloader_blob | awk '{print $1}')
@@ -104,5 +125,11 @@ fi
 
 # Sync internal memory
 sync /dev/mmcblk0
+
+# Update slot selection after the qspi was updated, otherwise
+# scratch register contents will be lost
+info_log "Setting active slot to ${new_slot}"
+/usr/bin/tegra-boot-control -e
+/usr/bin/tegra-boot-control -a ${new_slot}
 
 info_log "Done."


### PR DESCRIPTION
The Xavier based boards do not have u-boot support, therefore
they currently do not support rollback-altboot. We can use the
a/b slot mechanism to rollback in case of a failed boot due to
a kernel crash.

Tested on Xavier NX Devkit SD-CARD only, needs testing on
Xavier NX eMMC and Xavier AGX.

Can be extended for the rest of the boards which do support
u-boot, but we need to ensure that this doesn't interfere
with the rollback-altboot mechanism in u-boot from
meta-balena first.