### PR TITLE
conf: disable user-ns for jetson-tx1

### DIFF
--- a/layers/meta-balena-jetson/conf/layer.conf
+++ b/layers/meta-balena-jetson/conf/layer.conf
@@ -35,3 +35,6 @@ SERIAL_CONSOLES_jetson-tx1 = "115200;ttyS0"
 SERIAL_CONSOLES_jetson-nano = "115200;ttyS0"
 SERIAL_CONSOLES_jetson-nano-emmc = "115200;ttyS0"
 SERIAL_CONSOLES_jetson-nano-2gb-devkit-emmc = "115200;ttyS0"
+
+# Leave user namespacing disabled at runtime to match upstream
+DISTRO_FEATURES_append_jetson-tx1 = " disable-user-ns"


### PR DESCRIPTION
Disable user namespacing for Jetson TX1 to match upstream behavior.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>