### PR TITLE
Update provisioning steps for Jetson Nano SD-CARD and 2GB SD-CARD

### DIFF
--- a/jetson-nano-2gb-devkit.coffee
+++ b/jetson-nano-2gb-devkit.coffee
@@ -1,8 +1,9 @@
 deviceTypesCommon = require '@resin.io/device-types/common'
 { networkOptions, commonImg, instructions } = deviceTypesCommon
 
-BOARD_POWEROFF = 'Remove power from the Jetson Nano 2GB Devkit and insert the freshly burnt sd-card.'
-BOARD_POWERON  = 'Power on the board.'
+BOARD_PREPARE  = 'Put the NVidia Jetson Nano 2GB Devkit in recovery mode'
+FLASH_TOOL = 'Unzip BalenaOS image and use the Jetson Flash tool to flash the board. Jetson Flash tool can be found at https://github.com/balena-os/jetson-flash'
+DONE_FLASHING  = 'After flashing is completed, please wait until the board is rebooted'
 
 module.exports =
 	version: 1
@@ -12,9 +13,9 @@ module.exports =
 	state: 'released'
 
 	instructions: [
-		instructions.ETCHER_SD
-		BOARD_POWEROFF
-		BOARD_POWERON
+		BOARD_PREPARE
+		FLASH_TOOL
+		DONE_FLASHING
 	]
 
 	gettingStartedLink:

--- a/jetson-nano.coffee
+++ b/jetson-nano.coffee
@@ -1,8 +1,9 @@
 deviceTypesCommon = require '@resin.io/device-types/common'
 { networkOptions, commonImg, instructions } = deviceTypesCommon
 
-BOARD_POWEROFF = 'Remove power from the Jetson Nano Devkit SD-CARD and insert the freshly burnt sd-card.'
-BOARD_POWERON  = 'Power on the board.'
+BOARD_PREPARE  = 'Put the NVidia Jetson Nano SD-CARD in recovery mode'
+FLASH_TOOL = 'Unzip BalenaOS image and use the Jetson Flash tool to flash the board. Jetson Flash tool can be found at https://github.com/balena-os/jetson-flash'
+DONE_FLASHING  = 'After flashing is completed, please wait until the board is rebooted'
 
 module.exports =
 	version: 1
@@ -13,9 +14,9 @@ module.exports =
 	state: 'released'
 
 	instructions: [
-		instructions.ETCHER_SD
-		BOARD_POWEROFF
-		BOARD_POWERON
+		BOARD_PREPARE
+		FLASH_TOOL
+		DONE_FLASHING
 	]
 
 	gettingStartedLink:


### PR DESCRIPTION
    It is reported that newer units come with the qspi memory
    pre-flashed with bootloaders that cannot run the BalenaOS image.
    
    Update the flashing instructions to recommend Jetson Flash,
    which writes both the image on the sd-card in the nano and
    the qspi flash, so that they match and boot the BalenaOS
    SD-CARD image.