### PR TITLE
Add AAEON BOXER-8221AI device type

### DIFF
--- a/boxer-8221-emmc.coffee
+++ b/boxer-8221-emmc.coffee
@@ -1,0 +1,44 @@
+deviceTypesCommon = require '@resin.io/device-types/common'
+{ networkOptions, commonImg, instructions } = deviceTypesCommon
+
+BOARD_PREPARE  = 'Put the AAEON BOXER 8221AI eMMC board in recovery mode'
+FLASH_TOOL = 'Unzip BalenaOS image and use the Jetson Flash tool to flash the board. Jetson Flash tool can be found at https://github.com/balena-os/jetson-flash'
+DONE_FLASHING  = 'After flashing is completed, please wait until the board is rebooted'
+
+module.exports =
+	version: 1
+	slug: 'boxer-8221-emmc'
+	aliases: [ 'boxer-8221-emmc' ]
+	name: 'AAEON BOXER 8221AI eMMC'
+	arch: 'aarch64'
+	state: 'released'
+
+	instructions: [
+		BOARD_PREPARE
+		FLASH_TOOL
+		DONE_FLASHING
+	]
+
+	gettingStartedLink:
+		windows: 'https://docs.balena.io/jetson-nano-emmc/nodejs/getting-started/#adding-your-first-device'
+		osx: 'https://docs.balena.io/jetson-nano-emmc/nodejs/getting-started/#adding-your-first-device'
+		linux: 'https://docs.balena.io/jetson-nano-emmc/nodejs/getting-started/#adding-your-first-device'
+
+	supportsBlink: false
+
+	yocto:
+		machine: 'boxer-8221-emmc'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
+		version: 'yocto-honister'
+		deployArtifact: 'balena-image-boxer-8221-emmc.balenaos-img'
+		compressed: true
+
+	options: [ networkOptions.group ]
+
+	configuration:
+		config:
+			partition: 12
+			path: '/config.json'
+
+	initialization: commonImg.initialization

--- a/boxer-8221-emmc.svg
+++ b/boxer-8221-emmc.svg
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="183.59"
+   height="43.759998"
+   id="svg3184"
+   version="1.1"
+   inkscape:version="0.47 r22583"
+   sodipodi:docname="New document 3">
+  <defs
+     id="defs3186">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3192" />
+    <inkscape:perspective
+       id="perspective3122"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <path
+         d="m 158.41,554.26 169.56,0 0,-51.69 -169.56,0 0,51.69 z"
+         clip-rule="evenodd"
+         id="path196" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <path
+         d="M 0.015,666.99 497,666.99 497,0 0.015,0 l 0,666.99 z"
+         id="path204" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.5549296"
+     inkscape:cx="95.714286"
+     inkscape:cy="14.285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1024"
+     inkscape:window-height="678"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3189">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-203.49321,-398.05129)">
+    <g
+       transform="matrix(1.25,0,0,-1.25,-0.70282389,1080.6489)"
+       id="g190">
+      <g
+         id="g192"
+         clip-path="url(#clipPath194)">
+        <g
+           id="g198">
+          <g
+             id="g200"
+             clip-path="url(#clipPath202)">
+            <g
+               id="g206"
+               transform="translate(214.328,544.66901)">
+              <path
+                 d="m 0,0 -10.019,0 -1.771,-3.027 12.067,0 L 0,0"
+                 style="fill:#ed1c24;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path208" />
+            </g>
+            <g
+               id="g210"
+               transform="translate(207.226,535.03101)">
+              <path
+                 d="m 0,0 0,-5.14 8.458,0 -0.924,10.059 -13.214,0 -5.89,-10.059 8.756,0 L 0,0"
+                 style="fill:#ed1c24;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path212" />
+            </g>
+            <g
+               id="g214"
+               transform="translate(207.226,517.588)">
+              <path
+                 d="m 0,0 9.588,0 -0.975,10.612 -8.613,0 0,-4.584 -6.249,0 2.509,4.584 -8.819,0 -0.191,-0.325 0.945,-10.281 2.61,0 0.759,2.029 L 0,2.035 0,0"
+                 style="fill:#ed1c24;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path216" />
+            </g>
+            <g
+               id="g218"
+               transform="translate(216.968,515.897)">
+              <path
+                 d="m 0,0 -9.742,0 0,-2.996 10.019,0 L 0,0"
+                 style="fill:#ed1c24;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path220" />
+            </g>
+            <g
+               id="g222"
+               transform="translate(299.724,541.642)">
+              <path
+                 d="M 0,0 9.081,0 9.779,2.71 0.644,2.71 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path224" />
+            </g>
+            <g
+               id="g226"
+               transform="translate(290.41499,544.352)">
+              <path
+                 d="m 0,0 -9.069,0 -0.702,-2.71 10.814,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path228" />
+            </g>
+            <g
+               id="g230"
+               transform="translate(296.92599,529.89101)">
+              <path
+                 d="m 0,0 8.866,0 2.58,10.059 -9.05,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path232" />
+            </g>
+            <g
+               id="g234"
+               transform="translate(292.108,539.95)">
+              <path
+                 d="m 0,0 -11.899,0 -2.606,-10.059 18.378,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path236" />
+            </g>
+            <g
+               id="g238"
+               transform="translate(290.554,517.588)">
+              <path
+                 d="m 0,0 12.081,0 2.722,10.612 -18.863,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path240" />
+            </g>
+            <g
+               id="g242"
+               transform="translate(292.44501,512.64799)">
+              <path
+                 d="m 0,0 8.939,0.064 0.817,3.185 -10.998,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path244" />
+            </g>
+            <g
+               id="g246"
+               transform="translate(274.416,517.588)">
+              <path
+                 d="m 0,0 8.829,0 2.514,10.612 -8.594,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path248" />
+            </g>
+            <g
+               id="g250"
+               transform="translate(273.104,512.52299)">
+              <path
+                 d="m 0,0 8.94,0 0.799,3.374 -8.864,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path252" />
+            </g>
+            <g
+               id="g254"
+               transform="translate(266.575,545.177)">
+              <path
+                 d="m 0,0 c -5.652,-0.029 -9.723,-1.715 -12.496,-3.535 l 19.643,0 C 4.272,-0.349 0,0 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path256" />
+            </g>
+            <g
+               id="g258"
+               transform="translate(254.556,529.89101)">
+              <path
+                 d="m 0,0 c 0.31,0.96 0.804,2.222 1.548,3.445 0,0 2.196,4.114 7.268,3.916 0,0 4.038,-0.585 3.711,-6.059 0,0 -0.042,-0.512 -0.176,-1.302 l 8.781,0 c 0.507,2.428 0.587,4.126 0.587,4.126 0.046,2.497 -0.498,4.426 -1.337,5.933 l -23.077,0 C -4.428,8.519 -5.229,7.233 -5.229,7.233 -7.099,4.587 -8.183,1.895 -8.794,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path260" />
+            </g>
+            <g
+               id="g262"
+               transform="translate(247.80499,514.61501)">
+              <path
+                 d="m 0,0 c 8.432,-6.468 18.452,0.126 18.452,0.126 0.58,0.353 1.108,0.748 1.622,1.156 l -21.228,0 C -0.526,0.417 0,0 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path264" />
+            </g>
+            <g
+               id="g266"
+               transform="translate(266.55,528.2)">
+              <path
+                 d="m 0,0 c -0.576,-2.292 -1.739,-5.325 -4.043,-6.966 0,0 -4.267,-3.285 -7.571,0.28 0,0 -1.882,2.076 -0.822,6.686 l -8.847,0 c -0.133,-0.532 -0.187,-0.84 -0.187,-0.84 -1.088,-4.507 -0.386,-7.708 0.578,-9.772 l 24.087,0 C 6.242,-7.388 7.872,-3.296 8.743,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path268" />
+            </g>
+            <g
+               id="g270"
+               transform="translate(249.13499,544.41499)">
+              <path
+                 d="m 0,0 -23.902,0 -0.714,-2.773 23.912,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path272" />
+            </g>
+            <g
+               id="g274"
+               transform="translate(232.77699,536.93401)">
+              <path
+                 d="m 0,0 14.458,0 0.766,3.016 -23.916,0 -2.586,-10.059 21.57,0 0.742,2.922 -12.096,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path276" />
+            </g>
+            <g
+               id="g278"
+               transform="translate(229.786,525.32899)">
+              <path
+                 d="m 0,0 12.124,0 0.727,2.871 -21.573,0 -2.727,-10.612 24.595,0 0.752,3.112 -15.091,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path280" />
+            </g>
+            <g
+               id="g282"
+               transform="translate(217.116,512.839)">
+              <path
+                 d="m 0,0 24.665,0 0.74,3.058 -24.619,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path284" />
+            </g>
+            <g
+               id="g286"
+               transform="translate(192.95799,544.41499)">
+              <path
+                 d="m 0,0 -10.018,0 -1.639,-2.773 11.912,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path288" />
+            </g>
+            <g
+               id="g290"
+               transform="translate(185.85699,534.77699)">
+              <path
+                 d="m 0,0 0,-4.886 8.435,0 -0.923,10.059 -13.068,0 -5.947,-10.059 8.827,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path292" />
+            </g>
+            <g
+               id="g294"
+               transform="translate(185.85699,517.588)">
+              <path
+                 d="m 0,0 9.565,0 -0.974,10.612 -8.591,0 0,-4.837 -6.249,0 2.646,4.837 -8.9,0 L -18.777,0 -9.412,0 -8.436,1.782 0,1.782 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path296" />
+            </g>
+            <g
+               id="g298"
+               transform="translate(185.85699,515.897)">
+              <path
+                 d="m 0,0 0,-3.249 10.018,0 L 9.72,0 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path300" />
+            </g>
+            <g
+               id="g302"
+               transform="translate(164.235,512.776)">
+              <path
+                 d="m 0,0 9.576,0 1.708,3.121 -9.438,0 L 0,0"
+                 style="fill:#2e3192;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 id="path304" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/layers/meta-balena-jetson/conf/machine/boxer-8221-emmc.conf
+++ b/layers/meta-balena-jetson/conf/machine/boxer-8221-emmc.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+##@NAME: boxer-8221-emmc
+##@DESCRIPTION: Machine configuration for the AAEON BOXER-8221AI eMMC
+
+require conf/machine/jetson-nano-devkit-emmc.conf
+
+# Remove $MACHINE which is prepended by including jetson-nano-devkit-emmc
+# and fix the order of overrides
+MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':jetson-nano-emmc:boxer-nano:${MACHINE}')}"

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-nvidia-t210-enable-sdmmc3.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-nvidia-t210-enable-sdmmc3.patch
@@ -1,0 +1,28 @@
+From d61db0277c2667954a9a525535b94d5118aea47d Mon Sep 17 00:00:00 2001
+From: Pelle van Gils <pelle@hwky.ai>
+Date: Thu, 13 Jan 2022 20:32:54 +0000
+Subject: [PATCH] nvidia/t210: enable sdmmc3
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Pelle van Gils <pelle@hwky.ai>
+---
+ .../t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi       | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi b/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi
+index bf4875be6fd9..3f2259933323 100644
+--- a/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi
++++ b/nvidia/platform/t210/porg/kernel-dts/tegra210-porg-p3448-common.dtsi
+@@ -279,7 +279,8 @@
+ 	};
+ 
+ 	sdhci@700b0400 {
+-		status = "disabled";
++		status = "okay";
++		nvidia,vmmc-always-on;
+ 		/delete-property/ keep-power-in-suspend;
+ 		/delete-property/ non-removable;
+ 		mmc-ddr-1_8v;
+-- 
+2.25.1
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -83,6 +83,10 @@ SRC_URI:append:cnx100-xavier-nx = " \
     file://tegra194-xavier-nx-cnx100.dtb \
 "
 
+SRC_URI:append:boxer-nano = " \
+    file://0001-nvidia-t210-enable-sdmmc3.patch \
+"
+
 TEGRA_INITRAMFS_INITRD = "0"
 
 BALENA_CONFIGS:remove:astro-tx2 = " mdraid"


### PR DESCRIPTION
Add device type for AAEON BOXER-8221AI.

I have added the common `boxer-nano` MACHINEOVERRIDE to allow easy addition of other devices from the same series: [AAEON NVIDIA AI](https://www.aaeon.com/en/c/aaeon-nvidia-ai-solutions).