### PR TITLE
Enable PMIC WDT on Xavier NX SD

### DIFF
--- a/layers/meta-balena-jetson/conf/layer.conf
+++ b/layers/meta-balena-jetson/conf/layer.conf
@@ -37,3 +37,9 @@ SERIAL_CONSOLES:jetson-nano-2gb-devkit-emmc = "115200;ttyS0"
 
 KERNEL_IMAGETYPES = "Image"
 KERNEL_IMAGETYPE = "Image"
+
+# Enable PMIC WDT in ODMDATA. This comes
+# disabled by default on standard ODMDATA 0xB8190000
+# We do so on the Xavier NX Devkit because of the following
+# issue: https://github.com/OE4T/meta-tegra/issues/891#issuecomment-1027875304
+ODMDATA:jetson-xavier-nx-devkit = "0xB81A0000"

--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-nxde-sdcard-flash_32.6.1.bb
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-nxde-sdcard-flash_32.6.1.bb
@@ -122,7 +122,7 @@ signfile() {
 
      python3 $tegraflashpy --bl nvtboot_recovery_cpu_t194.bin \
         --sdram_config tegra194-mb1-bct-memcfg-p3668-0001-a00.cfg,tegra194-memcfg-sw-override.cfg  \
-        --odmdata 0xB8190000 \
+        --odmdata ${ODMDATA} \
         --applet mb1_t194_prod.bin \
         --cmd "sign$1" \
         --soft_fuses tegra194-mb1-soft-fuses-l4t.cfg  \

--- a/layers/meta-balena-jetson/recipes-bsp/tools/tegra-boot-tools_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/tools/tegra-boot-tools_%.bbappend
@@ -22,7 +22,7 @@ SYSTEMD_SERVICE:${PN} += " mark-active-slot.service"
 
 # Upon rollback to a release that does not have
 # this feature implemented, the _a slots will
-# be used by default, without chaning behavior.
+# be used by default, without changing behavior.
 do_install:append() {
     install -m 0755 ${WORKDIR}/mark_active_tegra_boot_slot.sh ${D}${bindir}/
     install -m 0644 ${WORKDIR}/mark-active-slot.service ${D}${systemd_unitdir}/system/

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-tegra-defconfig-Use-PMIC-WDT.patch
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra/0001-tegra-defconfig-Use-PMIC-WDT.patch
@@ -1,0 +1,37 @@
+From cdbcfbdcf3d81a7cde622a376f4dac15f9a3521d Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Wed, 2 Feb 2022 14:38:52 +0100
+Subject: [PATCH] tegra-defconfig: Disable Tegra WDT when using PMIC WDT
+
+Having both Tegra WDT and PMIC WDT running
+causes the device to reboot when using systemd
+to kick the watchdog. Let's leave the PMIC
+WDT enabled only, see:
+https://github.com/OE4T/meta-tegra/issues/891#issuecomment-1027875304
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ arch/arm64/configs/tegra_defconfig | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/configs/tegra_defconfig b/arch/arm64/configs/tegra_defconfig
+index 29ad9696c373..6a092c6a9721 100644
+--- a/arch/arm64/configs/tegra_defconfig
++++ b/arch/arm64/configs/tegra_defconfig
+@@ -699,9 +699,9 @@ CONFIG_USERSPACE_THERM_ALERT=m
+ CONFIG_WATCHDOG=y
+ CONFIG_WATCHDOG_NOWAYOUT=y
+ CONFIG_MAX77620_WATCHDOG=y
+-CONFIG_TEGRA21X_WATCHDOG=y
+-CONFIG_TEGRA18X_WATCHDOG=y
+-CONFIG_SOFT_PLATFORM_WATCHDOG=y
++#CONFIG_TEGRA21X_WATCHDOG=y
++#CONFIG_TEGRA18X_WATCHDOG=y
++#CONFIG_SOFT_PLATFORM_WATCHDOG=y
+ CONFIG_MFD_MAX77620=y
+ CONFIG_REGULATOR=y
+ CONFIG_REGULATOR_FIXED_VOLTAGE=y
+-- 
+2.17.1
+

--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -32,6 +32,14 @@ SRC_URI:append:jetson-xavier-nx-devkit-seeed-2mic-hat = " \
     file://tegra194-p3668-all-p3509-0000-seeed-2mic-hat.dtb \
 "
 
+# On the NX Devkit SD-CARD only the PMIC WDT
+# is enabled, the other watchdog modules
+# need to be disabled so that they don't
+# interfere.
+SRC_URI:append:jetson-xavier-nx-devkit = " \
+    file://0001-tegra-defconfig-Use-PMIC-WDT.patch \
+"
+
 SRC_URI:append:cti-rogue-xavier = " \
     file://tegra194-agx-cti-AGX101.dtb \
 "


### PR DESCRIPTION
We do so to overcome a very sporadic hang in cboot 32.6.1 which appears
to happen sometimes when cboot cannot detect partition on the SD-CARD.

This appears to happen very seldom, right after a reboot, thus we enable
PMIC WDT to reboot the device in this case.

Connects-to: https://github.com/OE4T/meta-tegra/issues/891#issuecomment-1027875304