### PR TITLE
hostapp-update-hooks: improve health rollbacks to older images

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/files/tx2_28_x_hook_fix.sh
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/files/tx2_28_x_hook_fix.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+set -o errexit
+
+flash() {
+    for line in $(cat $1); do
+        part_name=$(echo $line | cut -d ':' -f 1)
+        file_name=$(echo $line | cut -d ':' -f 2)
+
+        dd oflag=dsync if="/opt/tegra-binaries/$update_dir/$file_name" of="/dev/disk/by-partlabel/$part_name"
+    done
+}
+
+#!/bin/sh
+
+set -o errexit
+
+DURING_UPDATE=${DURING_UPDATE:-0}
+num_parts=$(sfdisk -l /dev/mmcblk0 | grep mmcblk0p | wc -l)
+
+# If rolling back from a 32.x system, we need
+# to rework the layout as it is expected by L4T 28.x
+# tegra firmware
+if [ "16" -ne ${num_parts} ]; then
+    for (( i=1; i <= ${num_parts}; ++i ))
+    do
+        if sfdisk --part-label /dev/mmcblk0 ${i} | grep -q "resin"; then
+           echo "Keeping BalenaOS partition ${i}"
+        else
+           sfdisk --delete /dev/mmcblk0 ${i} || true
+        fi
+    done
+
+    start="8192"
+    sectors="8191"
+    partitions=$(cat /opt/tegra-binaries/partition_specification.txt)
+    i=1;
+    for n in ${partitions}; do
+        part_name=$(echo ${n} | cut -d ":" -f 1)
+        file_name=$(echo ${n} | cut -d ":" -f 2)
+        # In older OS releases we don't have parted, only fdisk and sfdisk
+        sed -e "s/\s*\([\+0-9a-zA-Z]*\).*/\1/" << EOF | fdisk /dev/mmcblk0 || true
+        n
+        ${i}
+        ${start}
+        +${sectors}
+        w
+EOF
+        sfdisk --part-label /dev/mmcblk0 ${i} ${part_name} || true
+        ((i=i+1))
+        dd if=/opt/tegra-binaries/${file_name} of=/dev/mmcblk0 conv=notrunc seek=${start}
+        start=$(expr ${start} \+ ${sectors} \+ 1)
+    done
+
+    # Ensure MBR has 16 partitions
+    sed -e "s/\s*\([\+0-9a-zA-Z]*\).*/\1/" << EOF | fdisk /dev/mmcblk0 || true
+    x
+    l
+    16
+    r
+    w
+EOF
+
+else
+    flash "/opt/tegra-binaries/partition_specification.txt"
+fi
+
+
+# Allow write to boot part
+echo 0 > /sys/block/mmcblk0boot0/force_ro
+dd if=/opt/tegra-binaries/boot0.img of=/dev/mmcblk0boot0 ; sync
+echo 1 > /sys/block/mmcblk0boot0/force_ro
+
+sync

--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra186-flash-dry_32.6.1.bb
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra186-flash-dry_32.6.1.bb
@@ -22,6 +22,7 @@ BOOT_BINDIFF:jetson-tx2-nx-devkit="boot0_t186_nx_devkit.bindiff"
 SRC_URI = " \
     file://resinOS-flash186.xml \
     file://partition_specification186.txt \
+    file://tx2_28_x_hook_fix.sh \
     file://${BOOT_BINDIFF} \
 "
 
@@ -248,6 +249,13 @@ do_install() {
     cp -r ${S}/tegraflash/signed/* ${D}/${BINARY_INSTALL_PATH}
     cp ${WORKDIR}/partition_specification186.txt ${D}/${BINARY_INSTALL_PATH}/
     cp ${DEPLOY_DIR_IMAGE}/bootfiles/boot0.img ${D}/${BINARY_INSTALL_PATH}/
+    # This file contains an updated hook for older L4T 28.X based images,
+    # which allows an older image to re-create the 28.X partition layout
+    # in case the rollback-health checks fail. The hostapp-update hook
+    # from the new L4T 32.X rootfs replaces the old 28.X hook with this
+    # improved one, if it has not been updated already. This is part of the
+    # ongoing improvement for L4T transitioning.
+    install -m 0755 ${WORKDIR}/tx2_28_x_hook_fix.sh ${D}/${BINARY_INSTALL_PATH}/
     rm -rf ${DEPLOY_DIR_IMAGE}/tegra-binaries
 }
 

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/50-resin-bootfiles-jetson-tx2
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/50-resin-bootfiles-jetson-tx2
@@ -9,6 +9,41 @@ UPGRADE_PARTITIONS=0
 BIN_INSTALL_PATH="/opt/tegra-binaries"
 OFFS=(1659 5243 18043)
 BOOT_BLOB="${BIN_INSTALL_PATH}/boot0.img"
+DURING_UPDATE=${DURING_UPDATE:-0}
+
+info_log()
+{
+    echo "[INFO] $@"
+}
+
+# Old 28.x based images are not able to re-write the
+# 28.x L4T partition layout with the offsets expected
+# by the tegra firmware at that revision. We therefore
+# patch the old hook so that it's able to boot after
+# a failed rollback-health.
+backport_rollback_health_fix()
+{
+    inactive_hook=$(find /mnt/sysroot/active/ -name "50-tx2-update")
+    # On 32.x releases this file was renamed, there's no need to update it
+    if [ -e ${inactive_hook} ]; then
+        if grep -q "DURING_UPDATE" "${inactive_hook}"; then
+            info_log "No need to backport rollback-health fix to old hook"
+        else
+            # Extra check, new 32.X systems use a different name for the partition spec file
+            old_part_spec=$(find /mnt/sysroot/active/ -name "partition_specification.txt")
+            if [ -e ${old_part_spec} ]; then
+                info_log "Will backport rollback-health fix to old hostapp-update hook"
+                cp "${BIN_INSTALL_PATH}/tx2_28_x_hook_fix.sh" ${inactive_hook}
+                info_log "Applied rollback-health fix to old hostapp-update hook"
+            else
+                info_log "Old partition specification file not found in current sysroot: ${old_part_spec}, hook will not be replaced!"
+            fi
+        fi
+    else
+        info_log "Upgrading from an L4T 32.X system, rollback-health fix is not needed"
+    fi
+}
+
 
 update_needed() {
     current_update_file=${1}
@@ -23,11 +58,6 @@ update_needed() {
     else
 	echo 0
     fi
-}
-
-info_log()
-{
-    echo "[INFO] $@"
 }
 
 get_odm_value() {
@@ -48,6 +78,19 @@ set_odm_value() {
         info_log "Writing ODM byte ${1} to ${2} at offset ${offset}"
         echo -n -e "\\x${1}" | dd of=${2} seek=${offset} bs=1 count=1 conv=notrunc
     done
+}
+
+fix_gpt_header()
+{
+    sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk ${DEV_PATH}
+    x
+    l
+    28
+    r
+    w
+EOF
+
+    partprobe /dev/mmcblk0 || true
 }
 
 update_partition_binaries()
@@ -77,17 +120,27 @@ else
 fi
 
 if [ ${UPGRADE_PARTITIONS} -eq 1 ]; then
+    backport_rollback_health_fix
     info_log "Removing old L4T 28.X partitions"
-    idx=1
-    while [ $idx -le 11 ]; do
-        parted -s ${DEV_PATH} rm ${idx}
-        idx=$(expr ${idx} \+ 1)
-    done
+
+    num_parts=$(sfdisk -l /dev/mmcblk0 | grep mmcblk0p | wc -l)
+    for (( idx=1; idx <= ${num_parts}; ++idx ))
+        do
+            if sfdisk --part-label /dev/mmcblk0 ${idx} | grep -q "resin"; then
+               echo "Ignore resin part ${idx}"
+            else
+               sfdisk --delete /dev/mmcblk0 ${idx} || true
+            fi
+        done
 
     info_log "Proceeding to create new L4T partitions"
 
-    partitions=$(cat "${BIN_INSTALL_PATH}/partition_specification186.txt")
+    # If the partition table was rolled-back to 28.X due to rollback-health,
+    # we first need to set the new (32.X) number of partitions in the MBR
+    # so that parted can add more partitions (were 16 originally)
+    fix_gpt_header
 
+    partitions=$(cat "${BIN_INSTALL_PATH}/partition_specification186.txt")
     start=${NVIDIA_PART_OFFSET}
     for n in ${partitions}; do
         part_name=$(echo $n | cut -d ':' -f 1)
@@ -100,17 +153,6 @@ if [ ${UPGRADE_PARTITIONS} -eq 1 ]; then
     done
 
     info_log "Created L4T 32.X partitions"
-
-    # Another issue with parted is incorrect number of partition entries
-    # in gpt header at position 0x250. Fix gpt header so it can be interpreted
-    # by the first bootloaders.
-    sed -e 's/\s*\([\+0-9a-zA-Z]*\).*/\1/' << EOF | fdisk ${DEV_PATH}
-    x
-    l
-    28
-    r
-    w
-EOF
 
 elif [ ${UPGRADE_PARTITIONS} -eq 0 ]; then
     update_partition_binaries "${BIN_INSTALL_PATH}/partition_specification186.txt"


### PR DESCRIPTION
In this commit we improve the old update hook that exists in L4T 28.X
based systems to allow reverting to the old 28.x partition layout.

Images that were releases on L4T 28.1, 28.2 etc did not support re-creating
the partition layout in case of a rollback, because the new 32.X layout
was not known at that point, and we were not aware that there could
be situations in which connectivity problems could cause the system
to roll back to an inconsistent state.

We therefore fix this, so in case the new L4T 32.6 based OS encounters
connectivity or engine related issues and rolls back, the updated hook
in the old OS re-writes the partition layout in the corresponding 28.x format,
with the offsets expected by the old tegra-bootloaders, thus allowing the
system to fully revert to the old OS.

Changelog-entry: hostapp-update-hooks: improve health rollbacks to older images
Signed-off-by: Alexandru Costache <alexandru@balena.io>