### PR TITLE
balena-image.inc: move rtl8822 module and firmware to TX2

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -160,13 +160,10 @@ IMAGE_INSTALL:append:jetson-tx2 = " \
     tegra-brcm-patchram \
     linux-firmware-bcm4354 \
     tegra-firmware-xusb \
+    tegra-firmware-rtl8822 \
     bt-scripts \
     jetson-dtbs \
     kernel-module-bcmdhd \
-"
-
-IMAGE_INSTALL:append:jetson-tx2-nx-devkit = " \
-    tegra-firmware-rtl8822 \
     kernel-module-rtk-btusb \
     kernel-module-rtl8822ce \
 "


### PR DESCRIPTION
At this moment this is only shipped for the NX devkit but the M.2 module can be plugged to any TX2 board that exposes the slot.
