### PR TITLE
balena-image.inc: move rtl8822 module and firmware to TX2

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -178,6 +178,7 @@ IMAGE_INSTALL_append_jetson-tx2 = " \
     tegra-firmware-xusb \
     bt-scripts \
     jetson-dtbs \
+    tegra-firmware-rtl8822 \
 "
 
 IMAGE_INSTALL_append_jetson-tx1 = " \


### PR DESCRIPTION
At this moment this is only shipped for the NX devkit but the M.2 module
can be plugged to any TX2 board that exposes the slot.

Changelog-entry: Ship rtl8822 module and firmware on TX2
Signed-off-by: Michal Toman <michalt@balena.io>