### PR TITLE
Check and fix invalid alternate gpt if necessary

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,4 +1,4 @@
-PACKAGE_INSTALL:append = " tegra-firmware-xusb"
+PACKAGE_INSTALL:append = " tegra-firmware-xusb gptfdisk initramfs-module-gptcheck"
 
 # Because of https://github.com/balena-os/balena-jetson/issues/90
 # the TX1 does not have a 32.X release currently. Let's decrease

--- a/layers/meta-balena-jetson/recipes-core/initrdscripts/files/gptcheck
+++ b/layers/meta-balena-jetson/recipes-core/initrdscripts/files/gptcheck
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+. /usr/libexec/os-helpers-fs
+. /usr/libexec/os-helpers-logging
+
+datapartition=$(get_state_path_from_label "resin-data")
+datapartitiondevice=$(basename $(readlink -f "${datapartition}"))
+datadevice=$(lsblk "/dev/${datapartitiondevice}" -d -n -o PKNAME)
+
+gptcheck_enabled() {
+    # On flasher avoid expanding partition
+    # shellcheck disable=SC2154
+    if [ "$bootparam_flasher" = "true" ]; then
+        info "Flasher detected. Will not perform GPT checks."
+        return 1
+    fi
+
+    return 0
+}
+
+gptcheck_run() {
+    # If the end GPT gets corrupted for whatever reason, restore it from the main GPT
+    # using sgdisk. parted is not able to fix this issue, and the jetson devices
+    # are the only ones that use GPT and need this tool.
+    if sgdisk -v /dev/${datadevice} 2>&1 | grep -q "invalid backup GPT header"; then
+        # /run is tmpfs
+        sgdisk --backup=/run/gpt.bkp /dev/${datadevice}
+        sgdisk --load-backup=/run/gpt.bkp /dev/${datadevice}
+    fi
+}

--- a/layers/meta-balena-jetson/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,5 +1,21 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+SRC_URI:append = " \
+    file://gptcheck \
+"
+
+do_install:append() {
+    install -m 0755 ${WORKDIR}/gptcheck ${D}/init.d/86-gptcheck
+}
+
+PACKAGES:append = " \
+    initramfs-module-gptcheck \
+"
+
+SUMMARY:initramfs-module-gptcheck = "Check and fix alternate GPT"
+RDEPENDS:initramfs-module-prepare = "${PN}-base os-helpers-logging os-helpers-fs"
+FILES:initramfs-module-gptcheck = "/init.d/86-gptcheck"
+
 SRC_URI:append:jetson-xavier = " \
     file://blockdev \
 "

--- a/layers/meta-balena-jetson/recipes-devtools/gptfdisk/gptfdisk_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-devtools/gptfdisk/gptfdisk_%.bbappend
@@ -1,0 +1,7 @@
+# Jetson devices use GPT. We use sgdisk to check and repair
+# the alternate GPT in case it gets corrupted from the initramfs,
+# and pack this tool only to keep the initramfs size to a minimum
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 sgdisk ${D}${sbindir}
+}


### PR DESCRIPTION
There has been a report that the Jetson-nano eMMC may not boot after the data partition has been filled in local mode and then some files were removed manually, in order to make some more space.

The following dmesg log is present in this case: ```Alternate GPT is invalid, using primary GPT.``` and the board hangs during boot in the initramfs, in partprobe.

We have tried to reproduce this issue locally by pushing apps that won't fit in the data partition multiple times, however, the end GPT did not get corrupt, which means the issue is sporadic, or that filling the data partition is not the root cause of the end GPT corruption.

We could corrupt the end GPT manually however with a line similar to: ```dd if=/dev/urandom of=/dev/mmcblk0 seek=<end_of_last_partition_in_sectors> bs=512 count=34 ```

In this PR we install the minimum of tools necessary for the initramfs to check and fix the end GPT if necessary.

We also install these in the Jetsons repository solely because the rest of devices use the msdos partition table type instead of GPT, and this would cause an increase of kernel size of approximately 200K.

Addresses: https://github.com/balena-os/balena-jetson/issues/271