### PR TITLE
blockdev: Allow for partitions to enumerate right after provisioning

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/initrdscripts/files/blockdev
+++ b/layers/meta-balena-jetson/recipes-core/initrdscripts/files/blockdev
@@ -7,4 +7,10 @@ blockdev_enabled() {
 blockdev_run() {
     # Trigger ioctl to read partitions
     /sbin/blockdev --rereadpt /dev/mmcblk0
+
+    # Starting with 32.7.1 BSP update, it's necessary to
+    # wait a few seconds for the partitions as well as their symlinks to
+    # be populated, otherwise the fsck and resindataexpander
+    # modules will not run. Five seconds proved to be enough in our tests.
+    sleep 5
 }


### PR DESCRIPTION
Starting with 32.7.1 the Xavier AGX needs a delay
for the partitions to enumerate after rereadpt
is triggered.

Changelog-entry: Allow for partitions to enumerate right after provisioning
Signed-off-by: Alexandru Costache <alexandru@balena.io>