### PR TITLE
linux-tegra: Enable NFSv4 config

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -261,6 +261,7 @@ BALENA_CONFIGS[nfsfs] = " \
     CONFIG_NFS_FS=m \
     CONFIG_NFS_V2=m \
     CONFIG_NFS_V3=m \
+    CONFIG_NFS_V4=m \
 "
 
 BALENA_CONFIGS[backlight] = " \


### PR DESCRIPTION
Changelog-entry: linux-tegra: Enable NFSv4 config
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Addreses: https://github.com/balena-os/balena-jetson/issues/353