### PR TITLE
linux-tegra: Enable NFS V4 server support

### DIFF
--- a/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -259,9 +259,11 @@ BALENA_CONFIGS[rtl8822ce] = " \
 BALENA_CONFIGS:append = " nfsfs backlight "
 BALENA_CONFIGS[nfsfs] = " \
     CONFIG_NFS_FS=m \
-    CONFIG_NFS_V2=m \
-    CONFIG_NFS_V3=m \
-    CONFIG_NFS_V4=m \
+    CONFIG_NFS_V2=y \
+    CONFIG_NFS_V3=y \
+    CONFIG_NFS_V4=y \
+    CONFIG_NFSD_V3=y \
+    CONFIG_NFSD_V4=y \
 "
 
 BALENA_CONFIGS[backlight] = " \


### PR DESCRIPTION
Connects-to: https://github.com/balena-os/balena-jetson/issues/353

Changelog-entry: linux-tegra: Enable NFS V4 server support
Signed-off-by: Alexandru Costache <alexandru@balena.io>