### PR TITLE
jetson-tx1: Flag as discontinued

### DIFF
--- a/jetson-tx1.coffee
+++ b/jetson-tx1.coffee
@@ -15,7 +15,7 @@ module.exports =
 	aliases: [ 'jetson-tx1' ]
 	name: 'Nvidia Jetson TX1'
 	arch: 'aarch64'
-	state: 'released'
+	state: 'discontinued'
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
The `state` field in device-type.json is no longer used by the cloud,
it's enough to set the hostapp as `is_archived`.

However, until we stop using device-type.json it would be confusing not
to update the state field.

Changelog-entry: Flag jetson-tx1 as discontinued
Signed-off-by: Alex Gonzalez <alexg@balena.io>