### PR TITLE
meta-balena-jetson: Move kernel signed binary to rootfs

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-flash-dry_32.7.2.bb
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra194-flash-dry_32.7.2.bb
@@ -210,7 +210,7 @@ do_configure() {
     cp ${WORKDIR}/resinOS-flash194.xml ${DEPLOY_DIR_IMAGE}/bootfiles/flash.xml
     cp -r signed/* ${DEPLOY_DIR_IMAGE}/bootfiles/
     cp -r ${DTBNAME}-root*_sigheader.dtb.encrypt ${DEPLOY_DIR_IMAGE}/bootfiles/
-    dd if=/dev/zero of="${DEPLOY_DIR_IMAGE}/bootfiles/bmp.blob" bs=1K count=70
+    dd if=/dev/zero of="${DEPLOY_DIR_IMAGE}/bootfiles/bmp.blob" bs=1K count=1
 
     # This is the Xavier boot0, which wasn't necessary for HUP from L4T 31.x to 32.3.1,
     # but becomes when moving to L4T 32.4.2 or newer.
@@ -281,9 +281,9 @@ do_configure() {
 do_install() {
     install -d ${D}/${BINARY_INSTALL_PATH}
     cp -r ${S}/tegraflash/signed/* ${D}/${BINARY_INSTALL_PATH}
-    # signed boot.img isn't needed in rootfs
     rm ${D}/${BINARY_INSTALL_PATH}/boot*im*
     cp ${S}/tegraflash/${DTBNAME}-rootA.dtb ${D}/${BINARY_INSTALL_PATH}/
+    cp ${DEPLOY_DIR_IMAGE}/bootfiles/boot_sigheader.img.encrypt ${D}/${BINARY_INSTALL_PATH}/
     cp ${WORKDIR}/partition_specification194.txt ${D}/${BINARY_INSTALL_PATH}/
     cp -r ${S}/tegraflash/${DTBNAME}-root*sigheader.dtb.encrypt ${D}/${BINARY_INSTALL_PATH}
     # When generating image, this will be default dtb containing cmdline with root set to resin-rootA

--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -64,7 +64,6 @@ BALENA_BOOT_PARTITION_FILES:jetson-xavier = " \
     bootfiles/camera-rtcpu-rce_sigheader.img.encrypt:/bootfiles/camera-rtcpu-rce_sigheader.img.encrypt \
     bootfiles/adsp-fw_sigheader.bin.encrypt:/bootfiles/adsp-fw_sigheader.bin.encrypt \
     bootfiles/warmboot_t194_prod_sigheader.bin.encrypt:/bootfiles/warmboot_t194_prod_sigheader.bin.encrypt \
-    bootfiles/boot_sigheader.img.encrypt:/bootfiles/boot_sigheader.img.encrypt \
     bootfiles/${DTBNAME}-rootA_sigheader.dtb.encrypt:/bootfiles/${DTBNAME}-rootA_sigheader.dtb.encrypt \
     bootfiles/${DTBNAME}-rootB_sigheader.dtb.encrypt:/bootfiles/${DTBNAME}-rootB_sigheader.dtb.encrypt \
     bootfiles/boot0.img:/bootfiles/boot0.img \

--- a/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
+++ b/layers/meta-balena-jetson/recipes-support/hostapp-update-hooks/files/99-resin-bootfiles-xavier
@@ -12,6 +12,7 @@ DURING_UPDATE=${DURING_UPDATE:-0}
 bootloader_device="/dev/mmcblk0boot0"
 partspec="/resin-boot/bootfiles/partition_specification194.txt"
 bootloader_blob="/resin-boot/bootfiles/boot0.img"
+bootpart_kernel="/mnt/boot/bootfiles/boot_sigheader.img.encrypt"
 
 info_log()
 {
@@ -31,6 +32,13 @@ backport_rollback_altboot_fix()
         sed -i 's/os-helpers-fs/os-helpers-fs \nDURING_UPDATE=${DURING_UPDATE:-0}\nif [ "$DURING_UPDATE" = "0" ]; then target_sysroot="active"; else target_sysroot="inactive"; fi; /g' ${inactive_hook}
         sed -i 's|/mnt/sysroot/inactive|/mnt/sysroot/${target_sysroot}|g' ${inactive_hook}
         info_log "Applied rollback-altboot fix to old hostapp-update hook"
+    fi
+
+    if [ -e ${bootpart_kernel} ]; then
+        rm ${bootpart_kernel}
+        info_log "Removed signed kernel binary from boot partition, it is now located in the rootfs"
+    else
+        info_log "No need to remove kernel binary from boot partition"
     fi
 }
 
@@ -153,7 +161,7 @@ dd if=/resin-boot/bootfiles/${dtbfile} of=$(get_state_path_from_label "kernel-dt
 
 info_log "Writing kernel ${kernel} to specific partitions..."
 
-dd if=/resin-boot/bootfiles/${kernel}  of=$(get_state_path_from_label "kernel${target_label_suffix}")
+dd if=/opt/tegra-binaries/${kernel}  of=$(get_state_path_from_label "kernel${target_label_suffix}")
 info_log "Updating boot image on hw partition mmcblk0boot0..."
 
 existing_bootloader_md5sum=$(dd if=$bootloader_device bs=1M status=none | md5sum | awk '{print $1}')


### PR DESCRIPTION
The kernel blob has been stored in the boot partition since long ago, but it has increased in size so we now need to store it in the rootfs.

Changelog-entry: meta-balena-jetson: Move kernel signed binary to rootfs
Signed-off-by: Alexandru Costache <alexandru@balena.io>