### PR TITLE
floyd-Nano: Discontinue device type

### DIFF
--- a/floyd-nano.coffee
+++ b/floyd-nano.coffee
@@ -10,7 +10,7 @@ module.exports =
 	slug: 'floyd-nano'
 	name: 'Floyd Nano BB02A eMMC'
 	arch: 'aarch64'
-	state: 'released'
+	state: 'discontinued'
 	community: true
 
 	instructions: [


### PR DESCRIPTION
This DT has not been maintained by the contributor since support was added. Marking it as discontinued as per internal discussion https://balena.zulipchat.com/#narrow/stream/345889-loop.2Fbalena-os/topic/Floyd.20Nano/near/315939998

Signed-off-by: Alexandru Costache <alexandru@balena.io>
Changelog-entry: floyd-Nano: Discontinue device type