### PR TITLE
Discontinue Blackboard TX2 and N310 TX2

### DIFF
--- a/blackboard-tx2.coffee
+++ b/blackboard-tx2.coffee
@@ -16,7 +16,7 @@ module.exports =
 	aliases: [ 'blackboard-tx2' ]
 	name: 'Nvidia blackboard TX2'
 	arch: 'aarch64'
-	state: 'released'
+	state: 'discontinued'
 	community: true
 
 	stateInstructions:

--- a/n310-tx2.coffee
+++ b/n310-tx2.coffee
@@ -15,7 +15,7 @@ module.exports =
 	aliases: [ 'n310-tx2' ]
 	name: 'Aetina N310 TX2'
 	arch: 'aarch64'
-	state: 'released'
+	state: 'discontinued'
 	community: true
 
 	stateInstructions:


### PR DESCRIPTION
These boards do not have any platform
registrations and have not been maintained
by contributors for more than 6 months.

Internal discussion: https://balena.zulipchat.com/#narrow/stream/345889-loop.2Fbalena-os/topic/Floyd.20Nano/near/322934815

Changelog-entry: Discontinue Blackboard TX2 and N310 TX2
Signed-off-by: Alexandru Costache <alexandru@balena.io>