### PR TITLE
balena-image-initramfs: remove recovery module

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
@@ -17,3 +17,5 @@ PACKAGE_INSTALL:remove:n310-tx2 = " mdraid"
 PACKAGE_INSTALL:remove:n510-tx2 = " mdraid"
 PACKAGE_INSTALL:remove:orbitty-tx2 = " mdraid"
 PACKAGE_INSTALL:remove:spacely-tx2 = " mdraid"
+
+PACKAGE_INSTALL:remove = " initramfs-module-recovery"


### PR DESCRIPTION
The Jetson family does not have enough space to increase the initramfs size and the recovery functionality does not fit in the current maximum space allocation of 32MB.

Changelog-entry: remove recovery module from balena-image-initramfs