### PR TITLE
tegra-bootfiles: Modify can parents for a04 bpmp on Xavier AGX

### DIFF
--- a/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra-bootfiles_32.7.3.bbappend
+++ b/layers/meta-balena-jetson/recipes-bsp/tegra-binaries/tegra-bootfiles_32.7.3.bbappend
@@ -1,7 +1,7 @@
 do_compile:prepend:tegra194() {
     for f in ${S}/bootloader/${NVIDIA_BOARD}/tegra194-*-bpmp-*.dtb;
     do
-        if [ $(basename "$f") = "tegra194-a02-bpmp-p2888-a01.dtb" ]; then
+        if [ $(basename "$f") = "tegra194-a02-bpmp-p2888-a04.dtb" ]; then
             echo "Changing parents for can1 and can2 in file $f"
             for dtnode in can1 can2
             do


### PR DESCRIPTION
tegra194-a02-bpmp-p2888-a04.dtb should be modified instead of tegra194-a02-bpmp-p2888-a01.dtb


Changelog-entry: tegra-bootfiles: Modify can parents for a04 bpmp for Xavier AGX