### PR TITLE
Add sample NM dispatcher script

### DIFF
--- a/layers/meta-balena-jetson/recipes-connectivity/networkmanager/files/50-sample-script
+++ b/layers/meta-balena-jetson/recipes-connectivity/networkmanager/files/50-sample-script
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+INTERFACE=$1
+ACTION=$2
+
+if [ "$INTERFACE" != "eth0" ]; then
+    exit 0                                           
+fi                                                   
+
+if [ "$ACTION" == "up" ]; then
+    echo "The ethernet interface has been activated"
+fi

--- a/layers/meta-balena-jetson/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-balena-jetson/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,13 @@
+# jetson-flash needs this directory to exist in the image
+# even if it is empty
+
+FILESEXTRAPATHS:append := ":${THISDIR}/files"
+
+SRC_URI:append = " \
+        file://50-sample-script \
+"
+
+do_deploy:append() {
+    mkdir -p "${DEPLOYDIR}/dispatcher.d/"
+    install -m 0755 "${WORKDIR}/50-sample-script" "${DEPLOYDIR}/dispatcher.d/"
+}

--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.bbappend
@@ -4,7 +4,7 @@ DEVICE_SPECIFIC_SPACE:jetson-nano = "49152"
 DEVICE_SPECIFIC_SPACE:jetson-nano-emmc = "49152"
 DEVICE_SPECIFIC_SPACE:jetson-nano-2gb-devkit = "49152"
 
-BALENA_BOOT_PARTITION_FILES:jetson-tx2 = " \
+BALENA_BOOT_PARTITION_FILES:append:jetson-tx2 = " \
     extlinux/extlinux.conf:/extlinux/extlinux.conf \
 "
 

--- a/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image.inc
@@ -25,8 +25,11 @@ DTBFILE:cnx100-xavier-nx = "tegra194-xavier-nx-cnx100.dtb"
 DTBNAME:jetson-xavier="tegra194-p2888-0001-p2822-0000"
 DTBNAME:jetson-xavier-nx-devkit-seeed-2mic-hat="tegra194-p3668-all-p3509-0000-seeed-2mic-hat"
 
-# Name update files as partition names for easier updating
-BALENA_BOOT_PARTITION_FILES:jetson-nano = " \
+BALENA_BOOT_PARTITION_FILES:append = " \
+    dispatcher.d/50-sample-script:/dispatcher.d/50-sample-script \
+"
+
+NANO_BOOT_PARTITION_FILES = " \
     bootfiles/nvtboot_cpu.bin.encrypt:/bootfiles/TBC \
     bootfiles/${DTBFILE}.encrypt:/bootfiles/RP1 \
     bootfiles/cboot.bin.encrypt:/bootfiles/EBT \
@@ -40,13 +43,15 @@ BALENA_BOOT_PARTITION_FILES:jetson-nano = " \
     bootfiles/bmp.blob:/bootfiles/BMP \
 "
 
-BALENA_BOOT_PARTITION_FILES:jetson-nano-emmc = "${BALENA_BOOT_PARTITION_FILES:jetson-nano}"
-BALENA_BOOT_PARTITION_FILES:jetson-nano-2gb-devkit = "${BALENA_BOOT_PARTITION_FILES:jetson-nano}"
+# Name update files as partition names for easier updating
+BALENA_BOOT_PARTITION_FILES:append:jetson-nano = " ${NANO_BOOT_PARTITION_FILES} "
+BALENA_BOOT_PARTITION_FILES:append:jetson-nano-emmc = "${NANO_BOOT_PARTITION_FILES}"
+BALENA_BOOT_PARTITION_FILES:append:jetson-nano-2gb-devkit = "${NANO_BOOT_PARTITION_FILES}"
 
 
 do_rootfs:balenaos-img:jetson-xavier[depends] += " tegra194-flash-dry:do_deploy "
 
-BALENA_BOOT_PARTITION_FILES:jetson-xavier = " \
+BALENA_BOOT_PARTITION_FILES:append:jetson-xavier = " \
     bootfiles/mb1_t194_prod_sigheader.bin.encrypt:/bootfiles/mb1_t194_prod_sigheader.bin.encrypt \
     bootfiles/spe_t194_sigheader.bin.encrypt:/bootfiles/spe_t194_sigheader.bin.encrypt \
     bootfiles/nvtboot_t194_sigheader.bin.encrypt:/bootfiles/nvtboot_t194_sigheader.bin.encrypt \


### PR DESCRIPTION
This is needed for jetson-flash so it can populate other scripts potentially added by users.

Fixes test failure and allows merging of https://github.com/balena-os/jetson-flash/pull/127 once a production image of jetson-tx2 is available with these changes included.