### PR TITLE
balena-image-initramfs: remove migrate module for jetson-tx2

### DIFF
--- a/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-jetson/recipes-core/images/balena-image-initramfs.bbappend
@@ -19,3 +19,4 @@ PACKAGE_INSTALL:remove:orbitty-tx2 = " mdraid"
 PACKAGE_INSTALL:remove:spacely-tx2 = " mdraid"
 
 PACKAGE_INSTALL:remove = " initramfs-module-recovery"
+PACKAGE_INSTALL:remove:jetson-tx2 = " initramfs-module-migrate"


### PR DESCRIPTION
Recent updates in the migrate module has increased its size and it makes the kernel no longer fit in the boot partition of the TX2.

Trying to merge https://github.com/balena-os/meta-balena/pull/3678/commits we see:
```
ERROR: balena-image-flasher-1.0-r0 do_resin_boot_dirgen_and_deploy: resin-boot: Not enough space for atomic copy operations.
ERROR: balena-image-flasher-1.0-r0 do_resin_boot_dirgen_and_deploy: ExecutionError('/home/alexgg/balena-jetson/build/tmp/work/jetson_tx2-poky-linux/balena-image-flasher/1.0-r0/temp/run.do_resin_boot_dirgen_and_deploy.1941646', 1, None, 
None)                                                                                                                 
ERROR: Logfile of failure stored in: /home/alexgg/balena-jetson/build/tmp/work/jetson_tx2-poky-linux/balena-image-flasher/1.0-r0/temp/log.do_resin_boot_dirgen_and_deploy.1941646
ERROR: Task (/home/alexgg/balena-jetson/build/../layers/meta-balena/meta-balena-common/recipes-core/images/balena-image-flasher.bb:do_resin_boot_dirgen_and_deploy) failed with exit code '1'
```


Changelog-entry: remove migrate module for the jetson-tx2