### PR TITLE
.gitmodules: Declare a branch for every submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,6 +17,7 @@
 [submodule "layers/meta-tegra"]
 	path = layers/meta-tegra
 	url = https://github.com/OE4T/meta-tegra.git
+	branch = kirkstone-l4t-r32.7.x
 [submodule "contracts"]
 	path = contracts
 	url = https://github.com/balena-io/contracts.git


### PR DESCRIPTION
`check_gitmodules_branches` fails while any submodule has no branch declared. One submodule had none here.

| Submodule | Branch | Basis |
|---|---|---|
| `layers/meta-tegra` | `kirkstone-l4t-r32.7.x` | ancestor, not on plain `kirkstone` |

Submodules that already declared a branch were left alone. I checked those declarations too, and they contain their pins.

Needed before #897 can be rebased. A plain retry of its Leviathan failures is unaffected.
